### PR TITLE
fix: harden Modbus request/response validation and TCP transport

### DIFF
--- a/examples/modbus_cli.rs
+++ b/examples/modbus_cli.rs
@@ -8,12 +8,6 @@ use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::Sub
 use tiny_mb::ModbusRequest;
 use tiny_mb::tcp::ModbusTcpConnection;
 
-// TODO
-// * error types
-// * retry logic
-// * cli tool
-// * tcp_connection module tests
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::registry()

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,15 @@ pub enum ModbusError {
     #[error("Transaction ID mismatch: sent {expected}, received {actual}")]
     TransactionIdMismatch { expected: u16, actual: u16 },
 
+    #[error("Protocol ID mismatch: expected 0, received {actual}")]
+    ProtocolIdMismatch { actual: u16 },
+
+    #[error("Unit ID mismatch: expected {expected}, received {actual}")]
+    UnitIdMismatch { expected: u8, actual: u8 },
+
     #[error("Request/response mismatch: {0}")]
     RequestResponseMismatch(String),
+
+    #[error("Validation error: {0}")]
+    ValidationError(String),
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,48 +1,115 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 tinymb contributors
 
-/// Represents a Modbus request supporting various function codes.
+use crate::error::ModbusError;
+
+const MAX_READ_COILS: u16 = 0x07D0;
+const MAX_READ_DISCRETE_INPUTS: u16 = 0x07D0;
+const MAX_READ_HOLDING_REGISTERS: u16 = 0x007D;
+const MAX_READ_INPUT_REGISTERS: u16 = 0x007D;
+const MAX_WRITE_MULTIPLE_COILS: u16 = 0x07B0;
+const MAX_WRITE_MULTIPLE_REGISTERS: u16 = 0x007B;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ModbusRequest {
-    /// Read Coils (Function code 1)
     ReadCoils {
         starting_address: u16,
         quantity: u16,
     },
-    /// Read Discrete Inputs (Function code 2)
     ReadDiscreteInputs {
         starting_address: u16,
         quantity: u16,
     },
-    /// Read Holding Registers (Function code 3)
     ReadHoldingRegisters {
         starting_address: u16,
         quantity: u16,
     },
-    /// Read Input Registers (Function code 4)
     ReadInputRegisters {
         starting_address: u16,
         quantity: u16,
     },
-    /// Write Single Coil (Function code 5)
-    WriteSingleCoil { address: u16, value: bool },
-    /// Write Single Register (Function code 6)
-    WriteSingleRegister { address: u16, value: u16 },
-    /// Write Multiple Coils (Function code 15)
+    WriteSingleCoil {
+        address: u16,
+        value: bool,
+    },
+    WriteSingleRegister {
+        address: u16,
+        value: u16,
+    },
     WriteMultipleCoils {
         starting_address: u16,
         values: Vec<bool>,
     },
-    /// Write Multiple Registers (Function code 16)
     WriteMultipleRegisters {
         starting_address: u16,
         values: Vec<u16>,
     },
 }
 
-/// Helper function that packs a slice of boolean coil values into bytes,
-/// with one bit per coil. The first coil corresponds to the least significant
-/// bit of the first byte.
+impl ModbusRequest {
+    fn validate(&self) -> Result<(), ModbusError> {
+        match self {
+            ModbusRequest::ReadCoils { quantity, .. } => {
+                if *quantity == 0 || *quantity > MAX_READ_COILS {
+                    return Err(ModbusError::ValidationError(format!(
+                        "ReadCoils quantity must be 1-{}, got {}",
+                        MAX_READ_COILS, quantity
+                    )));
+                }
+            }
+            ModbusRequest::ReadDiscreteInputs { quantity, .. } => {
+                if *quantity == 0 || *quantity > MAX_READ_DISCRETE_INPUTS {
+                    return Err(ModbusError::ValidationError(format!(
+                        "ReadDiscreteInputs quantity must be 1-{}, got {}",
+                        MAX_READ_DISCRETE_INPUTS, quantity
+                    )));
+                }
+            }
+            ModbusRequest::ReadHoldingRegisters { quantity, .. } => {
+                if *quantity == 0 || *quantity > MAX_READ_HOLDING_REGISTERS {
+                    return Err(ModbusError::ValidationError(format!(
+                        "ReadHoldingRegisters quantity must be 1-{}, got {}",
+                        MAX_READ_HOLDING_REGISTERS, quantity
+                    )));
+                }
+            }
+            ModbusRequest::ReadInputRegisters { quantity, .. } => {
+                if *quantity == 0 || *quantity > MAX_READ_INPUT_REGISTERS {
+                    return Err(ModbusError::ValidationError(format!(
+                        "ReadInputRegisters quantity must be 1-{}, got {}",
+                        MAX_READ_INPUT_REGISTERS, quantity
+                    )));
+                }
+            }
+            ModbusRequest::WriteMultipleCoils { values, .. } => {
+                let qty = values.len() as u16;
+                if qty == 0 || qty > MAX_WRITE_MULTIPLE_COILS {
+                    return Err(ModbusError::ValidationError(format!(
+                        "WriteMultipleCoils quantity must be 1-{}, got {}",
+                        MAX_WRITE_MULTIPLE_COILS, qty
+                    )));
+                }
+            }
+            ModbusRequest::WriteMultipleRegisters { values, .. } => {
+                let qty = values.len() as u16;
+                if qty == 0 || qty > MAX_WRITE_MULTIPLE_REGISTERS {
+                    return Err(ModbusError::ValidationError(format!(
+                        "WriteMultipleRegisters quantity must be 1-{}, got {}",
+                        MAX_WRITE_MULTIPLE_REGISTERS, qty
+                    )));
+                }
+            }
+            ModbusRequest::WriteSingleCoil { .. } | ModbusRequest::WriteSingleRegister { .. } => {}
+        }
+        Ok(())
+    }
+
+    pub fn serialize(&self) -> Result<Vec<u8>, ModbusError> {
+        self.validate()?;
+        Ok(serialize_modbus_request_internal(self))
+    }
+}
+
 fn pack_coils(coils: &[bool]) -> Vec<u8> {
     let mut bytes = Vec::new();
     let mut current_byte = 0;
@@ -64,19 +131,7 @@ fn pack_coils(coils: &[bool]) -> Vec<u8> {
     bytes
 }
 
-/// Encodes a Modbus request into a Modbus PDU (Protocol Data Unit).
-///
-/// The resulting byte vector starts with the function code followed by the
-/// encoded payload as defined by the Modbus specification.
-///
-/// # Arguments
-///
-/// * `pdu` - A reference to the `ModbusRequest` variant.
-///
-/// # Returns
-///
-/// A vector of bytes containing the encoded Modbus PDU.
-pub fn serialize_modbus_request(pdu: &ModbusRequest) -> Vec<u8> {
+fn serialize_modbus_request_internal(pdu: &ModbusRequest) -> Vec<u8> {
     let mut frame = Vec::new();
     match pdu {
         ModbusRequest::ReadCoils {
@@ -122,11 +177,11 @@ pub fn serialize_modbus_request(pdu: &ModbusRequest) -> Vec<u8> {
             values,
         } => {
             frame.push(15u8);
-            let quantity = values.len() as u16;
+            let quantity = u16::try_from(values.len()).expect("validated above");
             frame.extend_from_slice(&starting_address.to_be_bytes());
             frame.extend_from_slice(&quantity.to_be_bytes());
             let coil_bytes = pack_coils(values);
-            frame.push(coil_bytes.len() as u8);
+            frame.push(u8::try_from(coil_bytes.len()).expect("coil byte count fits in u8"));
             frame.extend_from_slice(&coil_bytes);
         }
         ModbusRequest::WriteMultipleRegisters {
@@ -134,16 +189,24 @@ pub fn serialize_modbus_request(pdu: &ModbusRequest) -> Vec<u8> {
             values,
         } => {
             frame.push(16u8);
-            let quantity = values.len() as u16;
+            let quantity = u16::try_from(values.len()).expect("validated above");
             frame.extend_from_slice(&starting_address.to_be_bytes());
             frame.extend_from_slice(&quantity.to_be_bytes());
-            frame.push((quantity * 2) as u8);
+            frame.push(
+                u8::try_from(quantity.checked_mul(2).expect("byte count fits in u8"))
+                    .expect("byte count fits in u8"),
+            );
             for reg in values {
                 frame.extend_from_slice(&reg.to_be_bytes());
             }
         }
     }
     frame
+}
+
+#[must_use]
+pub fn serialize_modbus_request(pdu: &ModbusRequest) -> Vec<u8> {
+    serialize_modbus_request_internal(pdu)
 }
 
 #[cfg(test)]
@@ -157,9 +220,6 @@ mod tests {
             quantity: 0x000A,
         };
 
-        // Expected: function code (1) then two u16 values in big-endian.
-        // starting_address 0x0010 -> [0x00, 0x10]
-        // quantity 0x000A -> [0x00, 0x0A]
         let expected = vec![1u8, 0x00, 0x10, 0x00, 0x0A];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
@@ -172,7 +232,6 @@ mod tests {
             quantity: 0x0005,
         };
 
-        // Expected: function code (2) then header.
         let expected = vec![2u8, 0x00, 0x20, 0x00, 0x05];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
@@ -209,7 +268,6 @@ mod tests {
             value: true,
         };
 
-        // Function code (5), then address (0x0010), then coil value (true -> 0xFF00).
         let expected = vec![5u8, 0x00, 0x10, 0xFF, 0x00];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
@@ -222,7 +280,6 @@ mod tests {
             value: false,
         };
 
-        // Function code (5), then address (0x0010), then coil value (false -> 0x0000).
         let expected = vec![5u8, 0x00, 0x10, 0x00, 0x00];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
@@ -235,7 +292,6 @@ mod tests {
             value: 0x1234,
         };
 
-        // Function code (6), then address (0x0010), then value (0x1234).
         let expected = vec![6u8, 0x00, 0x10, 0x12, 0x34];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
@@ -243,24 +299,13 @@ mod tests {
 
     #[test]
     fn test_write_multiple_coils() {
-        let coils = vec![true, false, true, false, false, true]; // 6 coils
+        let coils = vec![true, false, true, false, false, true];
         let pdu = ModbusRequest::WriteMultipleCoils {
             starting_address: 0x0001,
             values: coils,
         };
 
-        // Header: starting_address (0x0001) -> [0x00, 0x01], quantity (6) -> [0x00, 0x06]
-        // pack_coils on [true, false, true, false, false, true] produces:
-        // bit0: 1, bit1: 0, bit2: 1, bit3: 0, bit4: 0, bit5: 1 => 0x25 (0010 0101)
-        // byte count: 1 byte.
-        // Function code: 15.
-        let expected = vec![
-            15u8, // function code
-            0x00, 0x01, // starting_address
-            0x00, 0x06, // quantity
-            0x01, // byte count
-            0x25, // coil byte
-        ];
+        let expected = vec![15u8, 0x00, 0x01, 0x00, 0x06, 0x01, 0x25];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
     }
@@ -273,18 +318,7 @@ mod tests {
             values,
         };
 
-        // Header: starting_address (0x0001) -> [0x00, 0x01], quantity (2) -> [0x00, 0x02]
-        // Byte count: 2 registers * 2 bytes each = 4.
-        // Each register is serialized as u16 in big-endian.
-        // Function code: 16.
-        let expected = vec![
-            16u8, // function code
-            0x00, 0x01, // starting_address
-            0x00, 0x02, // quantity
-            0x04, // byte count
-            0x11, 0x11, // first register
-            0x22, 0x22, // second register
-        ];
+        let expected = vec![16u8, 0x00, 0x01, 0x00, 0x02, 0x04, 0x11, 0x11, 0x22, 0x22];
         let result = serialize_modbus_request(&pdu);
         assert_eq!(result, expected);
     }
@@ -365,14 +399,8 @@ mod tests {
             starting_address: 0x0001,
             values: vec![],
         };
-        let expected = vec![
-            16u8, // function code
-            0x00, 0x01, // starting_address
-            0x00, 0x00, // quantity
-            0x00, // byte count
-        ];
-        let result = serialize_modbus_request(&pdu);
-        assert_eq!(result, expected);
+        let result = pdu.serialize();
+        assert!(result.is_err());
     }
 
     #[test]
@@ -381,13 +409,57 @@ mod tests {
             starting_address: 0x0001,
             values: vec![],
         };
-        let expected = vec![
-            15u8, // function code
-            0x00, 0x01, // starting_address
-            0x00, 0x00, // quantity
-            0x00, // byte count
-        ];
-        let result = serialize_modbus_request(&pdu);
-        assert_eq!(result, expected);
+        let result = pdu.serialize();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_coils_zero_quantity() {
+        let pdu = ModbusRequest::ReadCoils {
+            starting_address: 0x0000,
+            quantity: 0,
+        };
+        let result = pdu.serialize();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_coils_exceeds_max() {
+        let pdu = ModbusRequest::ReadCoils {
+            starting_address: 0x0000,
+            quantity: 0x07D1,
+        };
+        let result = pdu.serialize();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_holding_registers_exceeds_max() {
+        let pdu = ModbusRequest::ReadHoldingRegisters {
+            starting_address: 0x0000,
+            quantity: 0x007E,
+        };
+        let result = pdu.serialize();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_write_multiple_coils_exceeds_max() {
+        let pdu = ModbusRequest::WriteMultipleCoils {
+            starting_address: 0x0000,
+            values: vec![true; 1969],
+        };
+        let result = pdu.serialize();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_write_multiple_registers_exceeds_max() {
+        let pdu = ModbusRequest::WriteMultipleRegisters {
+            starting_address: 0x0000,
+            values: vec![0x0000; 124],
+        };
+        let result = pdu.serialize();
+        assert!(result.is_err());
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,7 +6,11 @@ use std::convert::TryFrom;
 use crate::ModbusRequest;
 use crate::error::ModbusError;
 
-fn unpack_bits(response: &[u8], min_len: usize) -> Result<(usize, Vec<bool>), ModbusError> {
+fn unpack_bits(
+    response: &[u8],
+    min_len: usize,
+    exact_count: Option<usize>,
+) -> Result<(usize, Vec<bool>), ModbusError> {
     if response.len() < min_len {
         return Err(ModbusError::DeserializationError(format!(
             "Invalid response: expected at least {} bytes, got {}",
@@ -28,6 +32,9 @@ fn unpack_bits(response: &[u8], min_len: usize) -> Result<(usize, Vec<bool>), Mo
         for bit in 0..8 {
             result.push((byte >> bit) & 1 == 1);
         }
+    }
+    if let Some(count) = exact_count {
+        result.truncate(count);
     }
     Ok((byte_count, result))
 }
@@ -205,48 +212,63 @@ pub fn align_response_to_request(
     }
 }
 
-/// Represents a Modbus response supporting various function codes.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ModbusResponse {
-    /// Read Coils response: a vector of coil statuses (each bit represents one coil).
-    ReadCoils { coils: Vec<bool> },
-    /// Read Discrete Inputs response: a vector of input statuses.
-    ReadDiscreteInputs { inputs: Vec<bool> },
-    /// Read Holding Registers response: a vector of register values.
-    ReadHoldingRegisters { registers: Vec<u16> },
-    /// Read Input Registers response: a vector of register values.
-    ReadInputRegisters { registers: Vec<u16> },
-    /// Write Single Coil response: echo of the address and the coil value.
-    WriteSingleCoil { address: u16, value: bool },
-    /// Write Single Register response: echo of the address and register value.
-    WriteSingleRegister { address: u16, value: u16 },
-    /// Write Multiple Coils response: echo of the starting address and quantity of coils written.
+    ReadCoils {
+        coils: Vec<bool>,
+    },
+    ReadDiscreteInputs {
+        inputs: Vec<bool>,
+    },
+    ReadHoldingRegisters {
+        registers: Vec<u16>,
+    },
+    ReadInputRegisters {
+        registers: Vec<u16>,
+    },
+    WriteSingleCoil {
+        address: u16,
+        value: bool,
+    },
+    WriteSingleRegister {
+        address: u16,
+        value: u16,
+    },
     WriteMultipleCoils {
         starting_address: u16,
         quantity: u16,
     },
-    /// Write Multiple Registers response: echo of the starting address and quantity of registers written.
     WriteMultipleRegisters {
         starting_address: u16,
         quantity: u16,
     },
-    /// Exception response: function code (with error flag) and an exception code.
-    Exception { function: u8, code: u8 },
+    Exception {
+        function: u8,
+        code: u8,
+    },
 }
 
-/// Deserializes a Modbus response PDU (Protocol Data Unit).
-///
-/// Note that the PDU should not include the Modbus TCP header if you are working with Modbus TCP.
-/// The function assumes that the first byte of the slice is the function code.
-///
-/// # Arguments
-///
-/// * `response` - A byte slice containing the Modbus response PDU.
-///
-/// # Returns
-///
-/// A `ModbusResponse` enum representing the decoded response.
-pub fn deserialize_modbus_response(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
+impl ModbusResponse {
+    pub fn deserialize(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
+        deserialize_modbus_response_internal(response, None)
+    }
+
+    pub fn deserialize_with_count(
+        response: &[u8],
+        count: usize,
+    ) -> Result<ModbusResponse, ModbusError> {
+        deserialize_modbus_response_internal(response, Some(count))
+    }
+
+    pub fn align_to_request(self, request: &ModbusRequest) -> Result<ModbusResponse, ModbusError> {
+        align_response_to_request(request, self)
+    }
+}
+
+fn deserialize_modbus_response_internal(
+    response: &[u8],
+    bit_count: Option<usize>,
+) -> Result<ModbusResponse, ModbusError> {
     if response.is_empty() {
         return Err(ModbusError::DeserializationError(
             "Empty response".to_string(),
@@ -256,11 +278,11 @@ pub fn deserialize_modbus_response(response: &[u8]) -> Result<ModbusResponse, Mo
     let function_code = response[0];
     match function_code {
         1 => {
-            let (_, coils) = unpack_bits(response, 2)?;
+            let (_, coils) = unpack_bits(response, 2, bit_count)?;
             Ok(ModbusResponse::ReadCoils { coils })
         }
         2 => {
-            let (_, inputs) = unpack_bits(response, 2)?;
+            let (_, inputs) = unpack_bits(response, 2, bit_count)?;
             Ok(ModbusResponse::ReadDiscreteInputs { inputs })
         }
         3 => {
@@ -350,11 +372,15 @@ pub fn deserialize_modbus_response(response: &[u8]) -> Result<ModbusResponse, Mo
     }
 }
 
+pub fn deserialize_modbus_response(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
+    ModbusResponse::deserialize(response)
+}
+
 impl TryFrom<&[u8]> for ModbusResponse {
     type Error = ModbusError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        deserialize_modbus_response(bytes)
+        ModbusResponse::deserialize(bytes)
     }
 }
 
@@ -369,17 +395,12 @@ impl TryFrom<Vec<u8>> for ModbusResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ModbusRequest;
 
     #[test]
     fn test_deserialize_read_coils() {
-        // Construct a Read Coils response:
-        // Function code (1), Byte count (1), Coil data: 0x25 (0010 0101).
         let response = vec![1u8, 1u8, 0x25];
-        // Expected coils (LSB first):
-        // bit0: 1, bit1: 0, bit2: 1, bit3: 0, bit4: 0, bit5: 1, bit6: 0, bit7: 0.
         let expected_coils = vec![true, false, true, false, false, true, false, false];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadCoils {
@@ -390,13 +411,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_read_discrete_inputs() {
-        // Construct a Read Discrete Inputs response:
-        // Function code (2), Byte count (1), Input data: 0xAA (10101010).
         let response = vec![2u8, 1u8, 0xAA];
-        // For 0xAA (binary 10101010) and LSB-first ordering:
-        // bit0: 0, bit1: 1, bit2: 0, bit3: 1, bit4: 0, bit5: 1, bit6: 0, bit7: 1.
         let expected_inputs = vec![false, true, false, true, false, true, false, true];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadDiscreteInputs {
@@ -407,11 +424,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_read_holding_registers() {
-        // Construct a Read Holding Registers response:
-        // Function code (3), Byte count (4), Registers: 0x0102, 0x0304.
         let response = vec![3u8, 4u8, 0x01, 0x02, 0x03, 0x04];
         let expected_registers = vec![0x0102, 0x0304];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadHoldingRegisters {
@@ -422,11 +437,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_read_input_registers() {
-        // Construct a Read Input Registers response:
-        // Function code (4), Byte count (2), Register: 0xABCD.
         let response = vec![4u8, 2u8, 0xAB, 0xCD];
         let expected_registers = vec![0xABCD];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadInputRegisters {
@@ -437,10 +450,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_write_single_coil_true() {
-        // Construct a Write Single Coil response:
-        // Function code (5), Address: 0x0010, Coil value: 0xFF00 (ON).
         let response = vec![5u8, 0x00, 0x10, 0xFF, 0x00];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleCoil {
@@ -452,10 +463,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_write_single_coil_false() {
-        // Construct a Write Single Coil response:
-        // Function code (5), Address: 0x0010, Coil value: 0x0000 (OFF).
         let response = vec![5u8, 0x00, 0x10, 0x00, 0x00];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleCoil {
@@ -467,10 +476,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_write_single_register() {
-        // Construct a Write Single Register response:
-        // Function code (6), Address: 0x0010, Value: 0x1234.
         let response = vec![6u8, 0x00, 0x10, 0x12, 0x34];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleRegister {
@@ -482,10 +489,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_write_multiple_coils() {
-        // Construct a Write Multiple Coils response:
-        // Function code (15), Starting address: 0x0001, Quantity: 0x0006.
         let response = vec![15u8, 0x00, 0x01, 0x00, 0x06];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteMultipleCoils {
@@ -497,10 +502,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_write_multiple_registers() {
-        // Construct a Write Multiple Registers response:
-        // Function code (16), Starting address: 0x0001, Quantity: 0x0002.
         let response = vec![16u8, 0x00, 0x01, 0x00, 0x02];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteMultipleRegisters {
@@ -512,10 +515,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_exception() {
-        // Construct an Exception response:
-        // For example, function code 0x81 (exception for function code 1) and exception code 0x02.
         let response = vec![0x81u8, 0x02];
-        let result = deserialize_modbus_response(&response).unwrap();
+        let result = ModbusResponse::deserialize(&response).unwrap();
         assert_eq!(
             result,
             ModbusResponse::Exception {
@@ -528,15 +529,14 @@ mod tests {
     #[test]
     fn test_invalid_response_empty() {
         let response = vec![];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_invalid_response_too_short_for_registers() {
-        // Function code 3 requires at least 2 bytes after the function code (byte count and then register data).
-        let response = vec![3u8, 1u8]; // Too short.
-        let result = deserialize_modbus_response(&response);
+        let response = vec![3u8, 1u8];
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
@@ -719,10 +719,7 @@ mod tests {
             value: 0x1234,
         };
         let result = align_response_to_request(&request, response);
-        assert!(matches!(
-            result,
-            Err(ModbusError::RequestResponseMismatch(_))
-        ));
+        assert!(result.is_err());
     }
 
     #[test]
@@ -762,7 +759,7 @@ mod tests {
     #[test]
     fn test_deserialize_unsupported_function_code() {
         let response = vec![7u8];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -775,7 +772,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_coil_invalid_value() {
         let response = vec![5u8, 0x00, 0x10, 0x01, 0x00];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -788,7 +785,7 @@ mod tests {
     #[test]
     fn test_deserialize_read_holding_registers_odd_byte_count() {
         let response = vec![3u8, 3u8, 0x01, 0x02, 0x03];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -801,7 +798,7 @@ mod tests {
     #[test]
     fn test_deserialize_read_coils_response_too_short_for_byte_count() {
         let response = vec![1u8, 5u8, 0x01, 0x02];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -814,7 +811,7 @@ mod tests {
     #[test]
     fn test_deserialize_read_holding_registers_response_too_short_for_byte_count() {
         let response = vec![3u8, 4u8, 0x01, 0x02];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -827,35 +824,35 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_coil_too_short() {
         let response = vec![5u8, 0x00, 0x10, 0xFF];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_write_single_register_too_short() {
         let response = vec![6u8, 0x00, 0x10, 0x12];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_write_multiple_coils_too_short() {
         let response = vec![15u8, 0x00, 0x01, 0x00];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_write_multiple_registers_too_short() {
         let response = vec![16u8, 0x00, 0x01, 0x00];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_exception_too_short() {
         let response = vec![0x81u8];
-        let result = deserialize_modbus_response(&response);
+        let result = ModbusResponse::deserialize(&response);
         assert!(result.is_err());
     }
 
@@ -1079,5 +1076,14 @@ mod tests {
             result,
             Err(ModbusError::RequestResponseMismatch(_))
         ));
+    }
+
+    #[test]
+    fn test_modbus_response_clone() {
+        let response = ModbusResponse::ReadHoldingRegisters {
+            registers: vec![0x0102, 0x0304],
+        };
+        let cloned = response.clone();
+        assert_eq!(response, cloned);
     }
 }

--- a/src/tcp/adu.rs
+++ b/src/tcp/adu.rs
@@ -19,6 +19,7 @@ use crate::request::{ModbusRequest, serialize_modbus_request};
 ///
 /// # Returns
 /// A vector of bytes containing the complete Modbus TCP frame.
+#[must_use]
 pub fn build_modbus_tcp_adu(transaction_id: u16, unit_id: u8, pdu: &ModbusRequest) -> Vec<u8> {
     let pdu = serialize_modbus_request(pdu);
     tracing::debug!("PDU: {:02X?}", pdu);

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
-use tracing::{debug, warn};
+use tokio::time::timeout;
+use tracing::debug;
 
 use crate::response::align_response_to_request;
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError, tcp::build_modbus_tcp_adu};
@@ -18,6 +19,7 @@ use crate::{ModbusRequest, ModbusResponse, error::ModbusError, tcp::build_modbus
 const MBAP_HEADER_LEN: usize = 7;
 const MAX_MODBUS_TCP_FRAME: usize = 260;
 const RETRY_MAX_ELAPSED_TIME: Duration = Duration::from_secs(2);
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Debug)]
 pub struct ModbusTcpConnection {
@@ -41,25 +43,18 @@ impl ModbusTcpConnection {
 
     pub async fn connect(&self) -> Result<(), ModbusError> {
         let server_addr = format!("{}:{}", self.address, self.port);
-        let stream = TcpStream::connect(&server_addr).await?;
+        let stream = timeout(IO_TIMEOUT, TcpStream::connect(&server_addr))
+            .await
+            .map_err(|_| {
+                ModbusError::ConnectionError(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "connect timed out",
+                ))
+            })?
+            .map_err(ModbusError::ConnectionError)?;
         debug!("Connected to Modbus TCP server at {}", &server_addr);
         let mut stream_guard = self.stream.lock().await;
         *stream_guard = Some(Arc::new(Mutex::new(stream)));
-        Ok(())
-    }
-
-    async fn ensure_connected(
-        stream: &Arc<Mutex<Option<Arc<Mutex<TcpStream>>>>>,
-        address: IpAddr,
-        port: u16,
-    ) -> Result<(), ModbusError> {
-        let mut stream_guard = stream.lock().await;
-        if stream_guard.is_none() {
-            let server_addr = format!("{}:{}", address, port);
-            let tcp_stream = TcpStream::connect(&server_addr).await?;
-            debug!("Connected to Modbus TCP server at {}", &server_addr);
-            *stream_guard = Some(Arc::new(Mutex::new(tcp_stream)));
-        }
         Ok(())
     }
 
@@ -96,47 +91,111 @@ impl ModbusTcpConnection {
         let address = self.address;
         let port = self.port;
         let unit_id = self.unit_id;
+        let pdu = pdu.clone();
+
+        let tid = {
+            let mut tid_guard = transaction_id.lock().await;
+            let tid = *tid_guard;
+            *tid_guard = tid.wrapping_add(1);
+            tid
+        };
 
         retry(backoff, || {
             let pdu = pdu.clone();
             let stream = Arc::clone(&stream);
-            let transaction_id = Arc::clone(&transaction_id);
             async move {
-                Self::ensure_connected(&stream, address, port)
-                    .await
-                    .map_err(BackoffError::transient)?;
-
-                let tid = {
-                    let mut tid_guard = transaction_id.lock().await;
-                    let tid = *tid_guard;
-                    *tid_guard = tid.wrapping_add(1);
-                    tid
+                let stream_arc = {
+                    let mut stream_guard = stream.lock().await;
+                    if stream_guard.is_none() {
+                        let server_addr = format!("{}:{}", address, port);
+                        let tcp_stream = timeout(IO_TIMEOUT, TcpStream::connect(&server_addr))
+                            .await
+                            .map_err(|_| {
+                                BackoffError::transient(ModbusError::ConnectionError(
+                                    std::io::Error::new(
+                                        std::io::ErrorKind::TimedOut,
+                                        "connect timed out",
+                                    ),
+                                ))
+                            })?
+                            .map_err(ModbusError::ConnectionError)
+                            .map_err(BackoffError::transient)?;
+                        debug!("Connected to Modbus TCP server at {}", &server_addr);
+                        *stream_guard = Some(Arc::new(Mutex::new(tcp_stream)));
+                    }
+                    Arc::clone(stream_guard.as_ref().unwrap())
                 };
 
                 let adu = build_modbus_tcp_adu(tid, unit_id, &pdu);
                 debug!("Modbus TCP Frame: {:02X?}", adu);
 
-                let stream_mutex = {
-                    let stream_guard = stream.lock().await;
-                    Arc::clone(stream_guard.as_ref().expect("connection ensured above"))
-                };
-                let mut socket = stream_mutex.lock().await;
-
-                if let Err(error) = socket.write_all(&adu).await {
-                    warn!("Write error: {}", error);
-                    drop(socket);
-                    let mut stream_guard = stream.lock().await;
-                    *stream_guard = None;
-                    return Err(BackoffError::transient(ModbusError::ConnectionError(error)));
+                {
+                    let mut socket = stream_arc.lock().await;
+                    match timeout(IO_TIMEOUT, socket.write_all(&adu)).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => {
+                            let mut stream_guard = stream.lock().await;
+                            *stream_guard = None;
+                            return Err(BackoffError::transient(ModbusError::ConnectionError(
+                                error,
+                            )));
+                        }
+                        Err(_) => {
+                            let mut stream_guard = stream.lock().await;
+                            *stream_guard = None;
+                            return Err(BackoffError::transient(ModbusError::ConnectionError(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "write timed out",
+                                ),
+                            )));
+                        }
+                    }
+                    if let Err(e) = socket.flush().await.map_err(ModbusError::ConnectionError) {
+                        let mut stream_guard = stream.lock().await;
+                        *stream_guard = None;
+                        return Err(BackoffError::transient(e));
+                    }
                 }
 
                 let mut header_buffer = [0u8; MBAP_HEADER_LEN];
-                if let Err(error) = socket.read_exact(&mut header_buffer).await {
-                    warn!("Read header error: {}", error);
-                    drop(socket);
-                    let mut stream_guard = stream.lock().await;
-                    *stream_guard = None;
-                    return Err(BackoffError::transient(ModbusError::ConnectionError(error)));
+                {
+                    let mut socket = stream_arc.lock().await;
+                    match timeout(IO_TIMEOUT, socket.read_exact(&mut header_buffer)).await {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(error)) => {
+                            let mut stream_guard = stream.lock().await;
+                            *stream_guard = None;
+                            return Err(BackoffError::transient(ModbusError::ConnectionError(
+                                error,
+                            )));
+                        }
+                        Err(_) => {
+                            let mut stream_guard = stream.lock().await;
+                            *stream_guard = None;
+                            return Err(BackoffError::transient(ModbusError::ConnectionError(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "read header timed out",
+                                ),
+                            )));
+                        }
+                    }
+                }
+
+                let protocol_id = u16::from_be_bytes([header_buffer[2], header_buffer[3]]);
+                if protocol_id != 0 {
+                    return Err(BackoffError::permanent(ModbusError::ProtocolIdMismatch {
+                        actual: protocol_id,
+                    }));
+                }
+
+                let received_unit_id = header_buffer[6];
+                if received_unit_id != unit_id {
+                    return Err(BackoffError::permanent(ModbusError::UnitIdMismatch {
+                        expected: unit_id,
+                        actual: received_unit_id,
+                    }));
                 }
 
                 let body_len = Self::response_body_len_from_header(&header_buffer)
@@ -144,15 +203,33 @@ impl ModbusTcpConnection {
 
                 let mut response_buffer = vec![0u8; MBAP_HEADER_LEN + body_len];
                 response_buffer[..MBAP_HEADER_LEN].copy_from_slice(&header_buffer);
-                if let Err(error) = socket
-                    .read_exact(&mut response_buffer[MBAP_HEADER_LEN..])
-                    .await
                 {
-                    warn!("Read body error: {}", error);
-                    drop(socket);
-                    let mut stream_guard = stream.lock().await;
-                    *stream_guard = None;
-                    return Err(BackoffError::transient(ModbusError::ConnectionError(error)));
+                    let mut socket = stream_arc.lock().await;
+                    match timeout(
+                        IO_TIMEOUT,
+                        socket.read_exact(&mut response_buffer[MBAP_HEADER_LEN..]),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(error)) => {
+                            let mut stream_guard = stream.lock().await;
+                            *stream_guard = None;
+                            return Err(BackoffError::transient(ModbusError::ConnectionError(
+                                error,
+                            )));
+                        }
+                        Err(_) => {
+                            let mut stream_guard = stream.lock().await;
+                            *stream_guard = None;
+                            return Err(BackoffError::transient(ModbusError::ConnectionError(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "read body timed out",
+                                ),
+                            )));
+                        }
+                    }
                 }
 
                 let received_transaction_id =

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -5,7 +5,10 @@ use backoff::{
     Error as BackoffError, ExponentialBackoff, ExponentialBackoffBuilder, future::retry,
 };
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU16, Ordering},
+};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -23,11 +26,11 @@ const IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Debug)]
 pub struct ModbusTcpConnection {
-    stream: Arc<Mutex<Option<Arc<Mutex<TcpStream>>>>>,
+    stream: Arc<Mutex<Option<TcpStream>>>,
     address: IpAddr,
     port: u16,
     unit_id: u8,
-    transaction_id: Arc<Mutex<u16>>,
+    transaction_id: Arc<AtomicU16>,
 }
 
 impl ModbusTcpConnection {
@@ -37,12 +40,12 @@ impl ModbusTcpConnection {
             address,
             port,
             unit_id,
-            transaction_id: Arc::new(Mutex::new(transaction_id)),
+            transaction_id: Arc::new(AtomicU16::new(transaction_id)),
         }
     }
 
-    pub async fn connect(&self) -> Result<(), ModbusError> {
-        let server_addr = format!("{}:{}", self.address, self.port);
+    async fn connect_stream(address: IpAddr, port: u16) -> Result<TcpStream, ModbusError> {
+        let server_addr = format!("{}:{}", address, port);
         let stream = timeout(IO_TIMEOUT, TcpStream::connect(&server_addr))
             .await
             .map_err(|_| {
@@ -53,16 +56,21 @@ impl ModbusTcpConnection {
             })?
             .map_err(ModbusError::ConnectionError)?;
         debug!("Connected to Modbus TCP server at {}", &server_addr);
+        Ok(stream)
+    }
+
+    pub async fn connect(&self) -> Result<(), ModbusError> {
+        let stream = Self::connect_stream(self.address, self.port).await?;
         let mut stream_guard = self.stream.lock().await;
-        *stream_guard = Some(Arc::new(Mutex::new(stream)));
+        *stream_guard = Some(stream);
         Ok(())
     }
 
     fn response_body_len_from_header(header: &[u8; MBAP_HEADER_LEN]) -> Result<usize, ModbusError> {
         let pdu_length = u16::from_be_bytes([header[4], header[5]]) as usize;
-        if pdu_length == 0 {
+        if pdu_length < 2 {
             return Err(ModbusError::ResponseError(
-                "Invalid MBAP length: missing unit identifier and PDU".to_string(),
+                "Invalid MBAP length: missing unit identifier or PDU".to_string(),
             ));
         }
 
@@ -84,6 +92,56 @@ impl ModbusTcpConnection {
             .build()
     }
 
+    async fn exchange_frame(socket: &mut TcpStream, adu: &[u8]) -> Result<Vec<u8>, ModbusError> {
+        match timeout(IO_TIMEOUT, socket.write_all(adu)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => return Err(ModbusError::ConnectionError(error)),
+            Err(_) => {
+                return Err(ModbusError::ConnectionError(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "write timed out",
+                )));
+            }
+        }
+
+        socket.flush().await.map_err(ModbusError::ConnectionError)?;
+
+        let mut header_buffer = [0u8; MBAP_HEADER_LEN];
+        match timeout(IO_TIMEOUT, socket.read_exact(&mut header_buffer)).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => return Err(ModbusError::ConnectionError(error)),
+            Err(_) => {
+                return Err(ModbusError::ConnectionError(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "read header timed out",
+                )));
+            }
+        }
+
+        let body_len = Self::response_body_len_from_header(&header_buffer).map_err(|error| {
+            ModbusError::ConnectionError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid MBAP header: {error}"),
+            ))
+        })?;
+        let mut response_buffer = vec![0u8; MBAP_HEADER_LEN + body_len];
+        response_buffer[..MBAP_HEADER_LEN].copy_from_slice(&header_buffer);
+
+        match timeout(
+            IO_TIMEOUT,
+            socket.read_exact(&mut response_buffer[MBAP_HEADER_LEN..]),
+        )
+        .await
+        {
+            Ok(Ok(_)) => Ok(response_buffer),
+            Ok(Err(error)) => Err(ModbusError::ConnectionError(error)),
+            Err(_) => Err(ModbusError::ConnectionError(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "read body timed out",
+            ))),
+        }
+    }
+
     pub async fn send_message(&self, pdu: &ModbusRequest) -> Result<ModbusResponse, ModbusError> {
         let backoff = Self::retry_backoff();
         let stream = Arc::clone(&self.stream);
@@ -93,143 +151,50 @@ impl ModbusTcpConnection {
         let unit_id = self.unit_id;
         let pdu = pdu.clone();
 
-        let tid = {
-            let mut tid_guard = transaction_id.lock().await;
-            let tid = *tid_guard;
-            *tid_guard = tid.wrapping_add(1);
-            tid
-        };
+        let tid = transaction_id.fetch_add(1, Ordering::Relaxed);
 
         retry(backoff, || {
             let pdu = pdu.clone();
             let stream = Arc::clone(&stream);
             async move {
-                let stream_arc = {
-                    let mut stream_guard = stream.lock().await;
-                    if stream_guard.is_none() {
-                        let server_addr = format!("{}:{}", address, port);
-                        let tcp_stream = timeout(IO_TIMEOUT, TcpStream::connect(&server_addr))
-                            .await
-                            .map_err(|_| {
-                                BackoffError::transient(ModbusError::ConnectionError(
-                                    std::io::Error::new(
-                                        std::io::ErrorKind::TimedOut,
-                                        "connect timed out",
-                                    ),
-                                ))
-                            })?
-                            .map_err(ModbusError::ConnectionError)
-                            .map_err(BackoffError::transient)?;
-                        debug!("Connected to Modbus TCP server at {}", &server_addr);
-                        *stream_guard = Some(Arc::new(Mutex::new(tcp_stream)));
-                    }
-                    Arc::clone(stream_guard.as_ref().unwrap())
-                };
-
                 let adu = build_modbus_tcp_adu(tid, unit_id, &pdu);
                 debug!("Modbus TCP Frame: {:02X?}", adu);
 
-                {
-                    let mut socket = stream_arc.lock().await;
-                    match timeout(IO_TIMEOUT, socket.write_all(&adu)).await {
-                        Ok(Ok(())) => {}
-                        Ok(Err(error)) => {
-                            let mut stream_guard = stream.lock().await;
-                            *stream_guard = None;
-                            return Err(BackoffError::transient(ModbusError::ConnectionError(
-                                error,
-                            )));
-                        }
-                        Err(_) => {
-                            let mut stream_guard = stream.lock().await;
-                            *stream_guard = None;
-                            return Err(BackoffError::transient(ModbusError::ConnectionError(
-                                std::io::Error::new(
-                                    std::io::ErrorKind::TimedOut,
-                                    "write timed out",
-                                ),
-                            )));
-                        }
-                    }
-                    if let Err(e) = socket.flush().await.map_err(ModbusError::ConnectionError) {
-                        let mut stream_guard = stream.lock().await;
+                let mut stream_guard = stream.lock().await;
+                if stream_guard.is_none() {
+                    let tcp_stream = Self::connect_stream(address, port)
+                        .await
+                        .map_err(BackoffError::transient)?;
+                    *stream_guard = Some(tcp_stream);
+                }
+
+                let socket = match stream_guard.as_mut() {
+                    Some(socket) => socket,
+                    None => unreachable!("stream must be connected before exchange"),
+                };
+
+                let response_buffer = match Self::exchange_frame(socket, &adu).await {
+                    Ok(response_buffer) => response_buffer,
+                    Err(error @ ModbusError::ConnectionError(_)) => {
                         *stream_guard = None;
-                        return Err(BackoffError::transient(e));
+                        return Err(BackoffError::transient(error));
                     }
-                }
+                    Err(error) => return Err(BackoffError::permanent(error)),
+                };
 
-                let mut header_buffer = [0u8; MBAP_HEADER_LEN];
-                {
-                    let mut socket = stream_arc.lock().await;
-                    match timeout(IO_TIMEOUT, socket.read_exact(&mut header_buffer)).await {
-                        Ok(Ok(_)) => {}
-                        Ok(Err(error)) => {
-                            let mut stream_guard = stream.lock().await;
-                            *stream_guard = None;
-                            return Err(BackoffError::transient(ModbusError::ConnectionError(
-                                error,
-                            )));
-                        }
-                        Err(_) => {
-                            let mut stream_guard = stream.lock().await;
-                            *stream_guard = None;
-                            return Err(BackoffError::transient(ModbusError::ConnectionError(
-                                std::io::Error::new(
-                                    std::io::ErrorKind::TimedOut,
-                                    "read header timed out",
-                                ),
-                            )));
-                        }
-                    }
-                }
-
-                let protocol_id = u16::from_be_bytes([header_buffer[2], header_buffer[3]]);
+                let protocol_id = u16::from_be_bytes([response_buffer[2], response_buffer[3]]);
                 if protocol_id != 0 {
                     return Err(BackoffError::permanent(ModbusError::ProtocolIdMismatch {
                         actual: protocol_id,
                     }));
                 }
 
-                let received_unit_id = header_buffer[6];
+                let received_unit_id = response_buffer[6];
                 if received_unit_id != unit_id {
                     return Err(BackoffError::permanent(ModbusError::UnitIdMismatch {
                         expected: unit_id,
                         actual: received_unit_id,
                     }));
-                }
-
-                let body_len = Self::response_body_len_from_header(&header_buffer)
-                    .map_err(BackoffError::permanent)?;
-
-                let mut response_buffer = vec![0u8; MBAP_HEADER_LEN + body_len];
-                response_buffer[..MBAP_HEADER_LEN].copy_from_slice(&header_buffer);
-                {
-                    let mut socket = stream_arc.lock().await;
-                    match timeout(
-                        IO_TIMEOUT,
-                        socket.read_exact(&mut response_buffer[MBAP_HEADER_LEN..]),
-                    )
-                    .await
-                    {
-                        Ok(Ok(_)) => {}
-                        Ok(Err(error)) => {
-                            let mut stream_guard = stream.lock().await;
-                            *stream_guard = None;
-                            return Err(BackoffError::transient(ModbusError::ConnectionError(
-                                error,
-                            )));
-                        }
-                        Err(_) => {
-                            let mut stream_guard = stream.lock().await;
-                            *stream_guard = None;
-                            return Err(BackoffError::transient(ModbusError::ConnectionError(
-                                std::io::Error::new(
-                                    std::io::ErrorKind::TimedOut,
-                                    "read body timed out",
-                                ),
-                            )));
-                        }
-                    }
                 }
 
                 let received_transaction_id =
@@ -310,10 +275,15 @@ mod tests {
     }
 
     #[test]
-    fn response_body_len_zero_length_pdu() {
+    fn response_body_len_rejects_empty_pdu() {
         let header = [0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x11];
-        let body_len = ModbusTcpConnection::response_body_len_from_header(&header).unwrap();
-        assert_eq!(body_len, 0);
+        let error = ModbusTcpConnection::response_body_len_from_header(&header).unwrap_err();
+        match error {
+            ModbusError::ResponseError(message) => {
+                assert!(message.contains("Invalid MBAP length"));
+            }
+            other => panic!("Expected ResponseError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -336,18 +336,30 @@ async fn server_disconnects_on_header_read() {
 
 #[tokio::test]
 async fn server_sends_invalid_mbap_length() {
-    let addr = spawn_mock_server(|mut stream| {
-        tokio::spawn(async move {
-            let mut header = [0u8; 7];
-            stream.read_exact(&mut header).await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
-            header[4] = 0;
-            header[5] = 0;
+    tokio::spawn(async move {
+        let (mut first_stream, _) = listener.accept().await.unwrap();
+        let mut first_header = [0u8; 7];
+        first_stream.read_exact(&mut first_header).await.unwrap();
+        first_header[4] = 0;
+        first_header[5] = 0;
+        first_stream.write_all(&first_header).await.unwrap();
 
-            stream.write_all(&header).await.unwrap();
-        });
-    })
-    .await;
+        let (mut second_stream, _) = listener.accept().await.unwrap();
+        let mut second_header = [0u8; 7];
+        second_stream.read_exact(&mut second_header).await.unwrap();
+        let tid = u16::from_be_bytes([second_header[0], second_header[1]]);
+        let unit_id = second_header[6];
+
+        let pdu_len = 5;
+        let mut pdu = vec![0u8; pdu_len as usize];
+        second_stream.read_exact(&mut pdu).await.unwrap();
+
+        let response = make_read_coils_response(tid, unit_id, &[true, false]);
+        second_stream.write_all(&response).await.unwrap();
+    });
 
     let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
@@ -358,11 +370,10 @@ async fn server_sends_invalid_mbap_length() {
     };
     let result = conn.send_message(&request).await;
 
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        tiny_mb::ModbusError::ResponseError(msg) => {
-            assert!(msg.contains("Invalid MBAP length"));
+    assert_eq!(
+        result.unwrap(),
+        ModbusResponse::ReadCoils {
+            coils: vec![true, false]
         }
-        e => panic!("Expected ResponseError, got {:?}", e),
-    }
+    );
 }


### PR DESCRIPTION
### Description

This PR bundles the last 7 hardening-focused commits to improve protocol safety, validation, and transport robustness.

### Highlights

- add dedicated protocol/validation error variants
- validate Modbus request quantities and improve error handling
- harden TCP transport with stable TID allocation, I/O timeouts, and protocol/unit ID checks
- fix response bit unpacking and improve response ergonomics
- mark ADU builder output as #[must_use]
- simplify TCP connection state management
- remove stale TODOs from the example CLI