### PR TITLE
ci: add GitHub Actions workflow and Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+      - name: Print coverage summary
+        run: cargo llvm-cov report --summary-only
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          # token: ${{ secrets.CODECOV_TOKEN }}  # required for private repos

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # tiny-mb
 
+[![CI](https://github.com/mattwend/tiny-mb/actions/workflows/ci.yml/badge.svg)](https://github.com/mattwend/tiny-mb/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/mattwend/tiny-mb/branch/main/graph/badge.svg)](https://codecov.io/gh/mattwend/tiny-mb)
+
 Small Rust Modbus library with typed request/response PDUs and a reusable Modbus TCP transport.
 
 ## Features

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: nearest
+  range: 0...100
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Add a CI pipeline and code coverage reporting for the project.

## Changes

### GitHub Actions workflow (`.github/workflows/ci.yml`)
- **Formatting** — runs `cargo fmt -- --check` to enforce consistent style
- **Clippy** — runs `cargo clippy` with `-D warnings` across all targets and features
- **Tests** — runs `cargo test --all-features`
- **Coverage** — generates an LCOV report via `cargo-llvm-cov` and uploads it to Codecov

All jobs use `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` where applicable.

The workflow triggers on pushes to `main` and on all pull requests.

### Codecov configuration (`codecov.yml`)
- Configures project and patch coverage targets
- Disables `fail_ci_if_error` so coverage upload issues don't block the pipeline