### PR TITLE
ci: enable Codecov token upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
-          # token: ${{ secrets.CODECOV_TOKEN }}  # required for private repos
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
Enable Codecov uploads by passing `CODECOV_TOKEN` to the Codecov GitHub Action.

## Why
The workflow generated coverage data, but uploads could fail because the token was not provided. This caused the Codecov badge to remain `unknown`.

## Changes
- uncommented the `token: ${{ secrets.CODECOV_TOKEN }}` input in `.github/workflows/ci.yml`

## Follow-up
- add `CODECOV_TOKEN` as a repository Actions secret in GitHub