### PR TITLE
refactor(api): consolidate Modbus response alignment and serialization APIs

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -146,7 +146,7 @@ impl ModbusRequest {
     /// Returns [`ModbusError::ValidationError`] when the request violates Modbus limits.
     pub fn serialize(&self) -> Result<Vec<u8>, ModbusError> {
         self.validate()?;
-        serialize_modbus_request_internal(self)
+        serialize_modbus_request(self)
     }
 }
 
@@ -171,9 +171,7 @@ fn pack_coils(coils: &[bool]) -> Vec<u8> {
     bytes
 }
 
-pub(crate) fn serialize_modbus_request_internal(
-    pdu: &ModbusRequest,
-) -> Result<Vec<u8>, ModbusError> {
+pub(crate) fn serialize_modbus_request(pdu: &ModbusRequest) -> Result<Vec<u8>, ModbusError> {
     let mut frame = Vec::with_capacity(MAX_REQUEST_PDU_LEN);
     match pdu {
         ModbusRequest::ReadCoils {
@@ -223,7 +221,7 @@ pub(crate) fn serialize_modbus_request_internal(
             starting_address,
             values,
         } => {
-            // `serialize_modbus_request` validates the public API bounds first.
+            // `ModbusRequest::serialize` validates the public API bounds first.
             // Keep the conversions defensive here as a backstop for crate-internal
             // callers and tests that bypass validation.
             frame.push(15u8);
@@ -249,7 +247,7 @@ pub(crate) fn serialize_modbus_request_internal(
             starting_address,
             values,
         } => {
-            // `serialize_modbus_request` validates the public API bounds first.
+            // `ModbusRequest::serialize` validates the public API bounds first.
             // Keep the conversions defensive here as a backstop for crate-internal
             // callers and tests that bypass validation.
             frame.push(16u8);
@@ -274,11 +272,6 @@ pub(crate) fn serialize_modbus_request_internal(
         }
     }
     Ok(frame)
-}
-
-pub(crate) fn serialize_modbus_request(pdu: &ModbusRequest) -> Result<Vec<u8>, ModbusError> {
-    pdu.validate()?;
-    serialize_modbus_request_internal(pdu)
 }
 
 #[cfg(test)]
@@ -579,15 +572,15 @@ mod tests {
     }
 
     /// Exercises the defensive `u16::try_from`/`u8::try_from` branches inside
-    /// `serialize_modbus_request_internal` by bypassing [`ModbusRequest::serialize`]'s
+    /// `serialize_modbus_request` by bypassing [`ModbusRequest::serialize`]'s
     /// validation step.
     #[test]
-    fn serialize_internal_write_multiple_coils_rejects_oversized_quantity() {
+    fn serialize_write_multiple_coils_rejects_oversized_quantity() {
         let pdu = ModbusRequest::WriteMultipleCoils {
             starting_address: 0x0000,
             values: vec![true; usize::from(u16::MAX) + 1],
         };
-        let err = serialize_modbus_request_internal(&pdu).unwrap_err();
+        let err = serialize_modbus_request(&pdu).unwrap_err();
         match err {
             ModbusError::ValidationError(msg) => {
                 assert!(msg.contains("WriteMultipleCoils"));
@@ -597,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_internal_write_multiple_coils_rejects_oversized_byte_count() {
+    fn serialize_write_multiple_coils_rejects_oversized_byte_count() {
         // Quantity fits in u16, but the packed-coil byte count overflows u8.
         // It intentionally exceeds the Modbus spec max to bypass public validation
         // and exercise the crate-internal defensive conversion.
@@ -605,7 +598,7 @@ mod tests {
             starting_address: 0x0000,
             values: vec![true; (usize::from(u8::MAX) + 1) * 8],
         };
-        let err = serialize_modbus_request_internal(&pdu).unwrap_err();
+        let err = serialize_modbus_request(&pdu).unwrap_err();
         match err {
             ModbusError::ValidationError(msg) => {
                 assert!(msg.contains("byte count"));
@@ -615,12 +608,12 @@ mod tests {
     }
 
     #[test]
-    fn serialize_internal_write_multiple_registers_rejects_oversized_quantity() {
+    fn serialize_write_multiple_registers_rejects_oversized_quantity() {
         let pdu = ModbusRequest::WriteMultipleRegisters {
             starting_address: 0x0000,
             values: vec![0x0000; usize::from(u16::MAX) + 1],
         };
-        let err = serialize_modbus_request_internal(&pdu).unwrap_err();
+        let err = serialize_modbus_request(&pdu).unwrap_err();
         match err {
             ModbusError::ValidationError(msg) => {
                 assert!(msg.contains("WriteMultipleRegisters"));
@@ -630,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_internal_write_multiple_registers_rejects_oversized_byte_count() {
+    fn serialize_write_multiple_registers_rejects_oversized_byte_count() {
         // Quantity fits in u16, but byte count (quantity * 2) overflows u8.
         // It intentionally exceeds the Modbus spec max (123 registers) to bypass
         // public validation and exercise the crate-internal defensive conversion.
@@ -638,7 +631,7 @@ mod tests {
             starting_address: 0x0000,
             values: vec![0x0000; 200],
         };
-        let err = serialize_modbus_request_internal(&pdu).unwrap_err();
+        let err = serialize_modbus_request(&pdu).unwrap_err();
         match err {
             ModbusError::ValidationError(msg) => {
                 assert!(msg.contains("byte count"));

--- a/src/response.rs
+++ b/src/response.rs
@@ -295,7 +295,7 @@ impl ModbusResponse {
     ///
     /// Returns [`ModbusError::DeserializationError`] when the bytes are not a supported response.
     pub fn deserialize(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
-        deserialize_modbus_response_internal(response, None)
+        deserialize_modbus_response(response, None)
     }
 
     /// Deserializes a Modbus response PDU and truncates bit-packed reads to `count` values.
@@ -307,7 +307,7 @@ impl ModbusResponse {
         response: &[u8],
         count: usize,
     ) -> Result<ModbusResponse, ModbusError> {
-        deserialize_modbus_response_internal(response, Some(count))
+        deserialize_modbus_response(response, Some(count))
     }
 
     /// Aligns this response with the request that produced it.
@@ -320,7 +320,7 @@ impl ModbusResponse {
     }
 }
 
-fn deserialize_modbus_response_internal(
+fn deserialize_modbus_response(
     response: &[u8],
     bit_count: Option<usize>,
 ) -> Result<ModbusResponse, ModbusError> {
@@ -423,15 +423,6 @@ fn deserialize_modbus_response_internal(
             "Unsupported function code: {function_code}"
         ))),
     }
-}
-
-/// Deserializes a Modbus response PDU.
-///
-/// # Errors
-///
-/// Returns [`ModbusError::DeserializationError`] when the bytes are not a supported response.
-pub fn deserialize_modbus_response(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
-    ModbusResponse::deserialize(response)
 }
 
 impl TryFrom<&[u8]> for ModbusResponse {
@@ -1191,14 +1182,6 @@ mod tests {
         let via_method = response.clone().align_to_request(&request).unwrap();
         let via_fn = align_response_to_request(&request, response).unwrap();
         assert_eq!(via_method, via_fn);
-    }
-
-    #[test]
-    fn deserialize_modbus_response_free_function_matches_method() {
-        let bytes = [3u8, 2, 0x12, 0x34];
-        let via_fn = deserialize_modbus_response(&bytes).unwrap();
-        let via_method = ModbusResponse::deserialize(&bytes).unwrap();
-        assert_eq!(via_fn, via_method);
     }
 
     #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -69,165 +69,6 @@ fn parse_registers(response: &[u8], min_len: usize) -> Result<Vec<u16>, ModbusEr
     Ok(registers)
 }
 
-/// Verifies that a decoded response matches the request that produced it.
-///
-/// # Errors
-///
-/// Returns [`ModbusError::RequestResponseMismatch`] when the response cannot
-/// be reconciled with the request.
-#[allow(clippy::too_many_lines)]
-pub fn align_response_to_request(
-    request: &ModbusRequest,
-    response: ModbusResponse,
-) -> Result<ModbusResponse, ModbusError> {
-    match (request, &response) {
-        (_, ModbusResponse::Exception { .. }) => Ok(response),
-        (
-            ModbusRequest::ReadCoils {
-                quantity: requested,
-                ..
-            },
-            ModbusResponse::ReadCoils { coils },
-        ) => {
-            if coils.len() < *requested as usize {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "ReadCoils: requested {} coils but got {}",
-                    requested,
-                    coils.len()
-                )));
-            }
-            let trimmed = coils[..*requested as usize].to_vec();
-            Ok(ModbusResponse::ReadCoils { coils: trimmed })
-        }
-        (
-            ModbusRequest::ReadDiscreteInputs {
-                quantity: requested,
-                ..
-            },
-            ModbusResponse::ReadDiscreteInputs { inputs },
-        ) => {
-            if inputs.len() < *requested as usize {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "ReadDiscreteInputs: requested {} inputs but got {}",
-                    requested,
-                    inputs.len()
-                )));
-            }
-            let trimmed = inputs[..*requested as usize].to_vec();
-            Ok(ModbusResponse::ReadDiscreteInputs { inputs: trimmed })
-        }
-        (
-            ModbusRequest::ReadHoldingRegisters {
-                quantity: requested,
-                ..
-            },
-            ModbusResponse::ReadHoldingRegisters { registers },
-        ) => {
-            if registers.len() != *requested as usize {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "ReadHoldingRegisters: requested {} registers but got {}",
-                    requested,
-                    registers.len()
-                )));
-            }
-            Ok(response)
-        }
-        (
-            ModbusRequest::ReadInputRegisters {
-                quantity: requested,
-                ..
-            },
-            ModbusResponse::ReadInputRegisters { registers },
-        ) => {
-            if registers.len() != *requested as usize {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "ReadInputRegisters: requested {} registers but got {}",
-                    requested,
-                    registers.len()
-                )));
-            }
-            Ok(response)
-        }
-        (
-            ModbusRequest::WriteSingleCoil { address, value },
-            ModbusResponse::WriteSingleCoil {
-                address: response_address,
-                value: response_value,
-            },
-        ) => {
-            if address != response_address || value != response_value {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "WriteSingleCoil: wrote address {address} value {value} but server echoed address {response_address} value {response_value}"
-                )));
-            }
-            Ok(response)
-        }
-        (
-            ModbusRequest::WriteSingleRegister { address, value },
-            ModbusResponse::WriteSingleRegister {
-                address: response_address,
-                value: response_value,
-            },
-        ) => {
-            if address != response_address || value != response_value {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "WriteSingleRegister: wrote address {address} value {value} but server echoed address {response_address} value {response_value}"
-                )));
-            }
-            Ok(response)
-        }
-        (
-            ModbusRequest::WriteMultipleCoils {
-                starting_address,
-                values,
-            },
-            ModbusResponse::WriteMultipleCoils {
-                starting_address: response_address,
-                quantity: resp_qty,
-            },
-        ) => {
-            let qty = u16::try_from(values.len()).map_err(|_| {
-                ModbusError::RequestResponseMismatch(format!(
-                    "WriteMultipleCoils: request quantity does not fit in u16: {}",
-                    values.len()
-                ))
-            })?;
-            if starting_address != response_address || qty != *resp_qty {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "WriteMultipleCoils: wrote address {starting_address} quantity {qty} but server acknowledged address {response_address} quantity {resp_qty}",
-                )));
-            }
-            Ok(response)
-        }
-        (
-            ModbusRequest::WriteMultipleRegisters {
-                starting_address,
-                values,
-            },
-            ModbusResponse::WriteMultipleRegisters {
-                starting_address: response_address,
-                quantity: resp_qty,
-            },
-        ) => {
-            let qty = u16::try_from(values.len()).map_err(|_| {
-                ModbusError::RequestResponseMismatch(format!(
-                    "WriteMultipleRegisters: request quantity does not fit in u16: {}",
-                    values.len()
-                ))
-            })?;
-            if starting_address != response_address || qty != *resp_qty {
-                return Err(ModbusError::RequestResponseMismatch(format!(
-                    "WriteMultipleRegisters: wrote address {starting_address} quantity {qty} but server acknowledged address {response_address} quantity {resp_qty}",
-                )));
-            }
-            Ok(response)
-        }
-        _ => Err(ModbusError::RequestResponseMismatch(format!(
-            "Request/response mismatch: got {response:?} for {request:?}"
-        ))),
-    }
-}
-
 /// Typed Modbus response PDUs.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ModbusResponse {
@@ -312,11 +153,165 @@ impl ModbusResponse {
 
     /// Aligns this response with the request that produced it.
     ///
+    /// # Arguments
+    ///
+    /// * `request` - The request expected to have produced this response.
+    ///
     /// # Errors
     ///
     /// Returns [`ModbusError::RequestResponseMismatch`] if the response does not match.
+    ///
+    /// # Returns
+    ///
+    /// Returns the validated response, trimming bit-packed read results to the requested count.
+    #[allow(clippy::too_many_lines)]
     pub fn align_to_request(self, request: &ModbusRequest) -> Result<ModbusResponse, ModbusError> {
-        align_response_to_request(request, self)
+        match (request, &self) {
+            (_, ModbusResponse::Exception { .. }) => Ok(self),
+            (
+                ModbusRequest::ReadCoils {
+                    quantity: requested,
+                    ..
+                },
+                ModbusResponse::ReadCoils { coils },
+            ) => {
+                if coils.len() < *requested as usize {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "ReadCoils: requested {} coils but got {}",
+                        requested,
+                        coils.len()
+                    )));
+                }
+                let trimmed = coils[..*requested as usize].to_vec();
+                Ok(ModbusResponse::ReadCoils { coils: trimmed })
+            }
+            (
+                ModbusRequest::ReadDiscreteInputs {
+                    quantity: requested,
+                    ..
+                },
+                ModbusResponse::ReadDiscreteInputs { inputs },
+            ) => {
+                if inputs.len() < *requested as usize {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "ReadDiscreteInputs: requested {} inputs but got {}",
+                        requested,
+                        inputs.len()
+                    )));
+                }
+                let trimmed = inputs[..*requested as usize].to_vec();
+                Ok(ModbusResponse::ReadDiscreteInputs { inputs: trimmed })
+            }
+            (
+                ModbusRequest::ReadHoldingRegisters {
+                    quantity: requested,
+                    ..
+                },
+                ModbusResponse::ReadHoldingRegisters { registers },
+            ) => {
+                if registers.len() != *requested as usize {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "ReadHoldingRegisters: requested {} registers but got {}",
+                        requested,
+                        registers.len()
+                    )));
+                }
+                Ok(self)
+            }
+            (
+                ModbusRequest::ReadInputRegisters {
+                    quantity: requested,
+                    ..
+                },
+                ModbusResponse::ReadInputRegisters { registers },
+            ) => {
+                if registers.len() != *requested as usize {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "ReadInputRegisters: requested {} registers but got {}",
+                        requested,
+                        registers.len()
+                    )));
+                }
+                Ok(self)
+            }
+            (
+                ModbusRequest::WriteSingleCoil { address, value },
+                ModbusResponse::WriteSingleCoil {
+                    address: response_address,
+                    value: response_value,
+                },
+            ) => {
+                if address != response_address || value != response_value {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "WriteSingleCoil: wrote address {address} value {value} but server echoed address {response_address} value {response_value}"
+                    )));
+                }
+                Ok(self)
+            }
+            (
+                ModbusRequest::WriteSingleRegister { address, value },
+                ModbusResponse::WriteSingleRegister {
+                    address: response_address,
+                    value: response_value,
+                },
+            ) => {
+                if address != response_address || value != response_value {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "WriteSingleRegister: wrote address {address} value {value} but server echoed address {response_address} value {response_value}"
+                    )));
+                }
+                Ok(self)
+            }
+            (
+                ModbusRequest::WriteMultipleCoils {
+                    starting_address,
+                    values,
+                },
+                ModbusResponse::WriteMultipleCoils {
+                    starting_address: response_address,
+                    quantity: resp_qty,
+                },
+            ) => {
+                let qty = u16::try_from(values.len()).map_err(|_| {
+                    ModbusError::RequestResponseMismatch(format!(
+                        "WriteMultipleCoils: request quantity does not fit in u16: {}",
+                        values.len()
+                    ))
+                })?;
+                if starting_address != response_address || qty != *resp_qty {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "WriteMultipleCoils: wrote address {starting_address} quantity {qty} but server acknowledged address {response_address} quantity {resp_qty}",
+                    )));
+                }
+                Ok(self)
+            }
+            (
+                ModbusRequest::WriteMultipleRegisters {
+                    starting_address,
+                    values,
+                },
+                ModbusResponse::WriteMultipleRegisters {
+                    starting_address: response_address,
+                    quantity: resp_qty,
+                },
+            ) => {
+                let qty = u16::try_from(values.len()).map_err(|_| {
+                    ModbusError::RequestResponseMismatch(format!(
+                        "WriteMultipleRegisters: request quantity does not fit in u16: {}",
+                        values.len()
+                    ))
+                })?;
+                if starting_address != response_address || qty != *resp_qty {
+                    return Err(ModbusError::RequestResponseMismatch(format!(
+                        "WriteMultipleRegisters: wrote address {starting_address} quantity {qty} but server acknowledged address {response_address} quantity {resp_qty}",
+                    )));
+                }
+                Ok(self)
+            }
+            _ => Err(ModbusError::RequestResponseMismatch(format!(
+                "Request/response mismatch: got {self:?} for {request:?}"
+            ))),
+        }
     }
 }
 
@@ -601,7 +596,7 @@ mod tests {
                 true, false, true, false, false, true, false, false, true, false, true, false,
             ],
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         match result {
             ModbusResponse::ReadCoils { coils } => {
                 assert_eq!(coils.len(), 10);
@@ -627,7 +622,7 @@ mod tests {
                 false, true, false, true, false, true, false, true, false, true, false, true,
             ],
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         match result {
             ModbusResponse::ReadDiscreteInputs { inputs } => {
                 assert_eq!(inputs.len(), 9);
@@ -649,7 +644,7 @@ mod tests {
         let response = ModbusResponse::ReadCoils {
             coils: vec![true, false, true, false, false, true, false, false],
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         match result {
             ModbusResponse::ReadCoils { coils } => {
                 assert_eq!(coils.len(), 8);
@@ -667,7 +662,7 @@ mod tests {
         let response = ModbusResponse::ReadDiscreteInputs {
             inputs: vec![false; 10],
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::RequestResponseMismatch(_) => {}
@@ -684,7 +679,7 @@ mod tests {
         let response = ModbusResponse::ReadHoldingRegisters {
             registers: vec![0x0102, 0x0304],
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
     }
 
@@ -697,7 +692,7 @@ mod tests {
         let response = ModbusResponse::ReadCoils {
             coils: vec![true, false, true, false, false, true, false, false],
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(matches!(
             result,
             Err(ModbusError::RequestResponseMismatch(_))
@@ -714,7 +709,7 @@ mod tests {
             function: 0x81,
             code: 0x02,
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::Exception {
@@ -734,7 +729,7 @@ mod tests {
             address: 0x0010,
             value: false,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(matches!(
             result,
             Err(ModbusError::RequestResponseMismatch(_))
@@ -751,7 +746,7 @@ mod tests {
             address: 0x0011,
             value: true,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(matches!(
             result,
             Err(ModbusError::RequestResponseMismatch(_))
@@ -768,7 +763,7 @@ mod tests {
             address: 0x0011,
             value: 0x1234,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
     }
 
@@ -782,7 +777,7 @@ mod tests {
             starting_address: 0x0000,
             quantity: 6,
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteMultipleCoils {
@@ -802,7 +797,7 @@ mod tests {
             starting_address: 0x0000,
             quantity: 5,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
     }
 
@@ -950,7 +945,7 @@ mod tests {
         let response = ModbusResponse::ReadInputRegisters {
             registers: vec![0x0102, 0x0304],
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
     }
 
@@ -964,7 +959,7 @@ mod tests {
             address: 0x0010,
             value: 0x5678,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
     }
 
@@ -978,7 +973,7 @@ mod tests {
             starting_address: 0x0000,
             quantity: 2,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(result.is_err());
     }
 
@@ -992,7 +987,7 @@ mod tests {
             starting_address: 0x0002,
             quantity: 3,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(matches!(
             result,
             Err(ModbusError::RequestResponseMismatch(_))
@@ -1009,7 +1004,7 @@ mod tests {
             starting_address: 0x0002,
             quantity: 3,
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(matches!(
             result,
             Err(ModbusError::RequestResponseMismatch(_))
@@ -1026,7 +1021,7 @@ mod tests {
             address: 0x0010,
             value: true,
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleCoil {
@@ -1046,7 +1041,7 @@ mod tests {
             address: 0x0010,
             value: 0x1234,
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleRegister {
@@ -1065,7 +1060,7 @@ mod tests {
         let response = ModbusResponse::ReadHoldingRegisters {
             registers: vec![0x0102, 0x0304],
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadHoldingRegisters {
@@ -1083,7 +1078,7 @@ mod tests {
         let response = ModbusResponse::ReadInputRegisters {
             registers: vec![0xABCD],
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadInputRegisters {
@@ -1102,7 +1097,7 @@ mod tests {
             starting_address: 0x0001,
             quantity: 2,
         };
-        let result = align_response_to_request(&request, response).unwrap();
+        let result = response.align_to_request(&request).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteMultipleRegisters {
@@ -1121,7 +1116,7 @@ mod tests {
         let response = ModbusResponse::ReadDiscreteInputs {
             inputs: vec![false; 5],
         };
-        let result = align_response_to_request(&request, response);
+        let result = response.align_to_request(&request);
         assert!(matches!(
             result,
             Err(ModbusError::RequestResponseMismatch(_))
@@ -1142,7 +1137,7 @@ mod tests {
             starting_address: 0,
             quantity: 1,
         };
-        let err = align_response_to_request(&request, response).unwrap_err();
+        let err = response.align_to_request(&request).unwrap_err();
         match err {
             ModbusError::RequestResponseMismatch(msg) => {
                 assert!(msg.contains("WriteMultipleCoils"));
@@ -1161,7 +1156,7 @@ mod tests {
             starting_address: 0,
             quantity: 1,
         };
-        let err = align_response_to_request(&request, response).unwrap_err();
+        let err = response.align_to_request(&request).unwrap_err();
         match err {
             ModbusError::RequestResponseMismatch(msg) => {
                 assert!(msg.contains("WriteMultipleRegisters"));
@@ -1171,7 +1166,7 @@ mod tests {
     }
 
     #[test]
-    fn align_to_request_method_delegates_to_free_function() {
+    fn align_to_request_method_aligns_response() {
         let request = ModbusRequest::ReadCoils {
             starting_address: 0,
             quantity: 2,
@@ -1179,9 +1174,13 @@ mod tests {
         let response = ModbusResponse::ReadCoils {
             coils: vec![true, false],
         };
-        let via_method = response.clone().align_to_request(&request).unwrap();
-        let via_fn = align_response_to_request(&request, response).unwrap();
-        assert_eq!(via_method, via_fn);
+        let aligned = response.align_to_request(&request).unwrap();
+        assert_eq!(
+            aligned,
+            ModbusResponse::ReadCoils {
+                coils: vec![true, false]
+            }
+        );
     }
 
     #[test]

--- a/src/tcp/adu.rs
+++ b/src/tcp/adu.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 tinymb contributors
 
 use crate::error::ModbusError;
-use crate::request::{ModbusRequest, serialize_modbus_request};
+use crate::request::ModbusRequest;
 
 const MBAP_HEADER_LEN: usize = 7;
 
@@ -31,7 +31,7 @@ pub fn build_modbus_tcp_adu(
     unit_id: u8,
     pdu: &ModbusRequest,
 ) -> Result<Vec<u8>, ModbusError> {
-    let pdu_bytes = serialize_modbus_request(pdu)?;
+    let pdu_bytes = pdu.serialize()?;
     build_modbus_tcp_adu_from_pdu_bytes(transaction_id, unit_id, &pdu_bytes)
 }
 

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -14,7 +14,6 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::debug;
 
-use crate::response::align_response_to_request;
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError, tcp::adu::build_modbus_tcp_adu};
 
 const MBAP_HEADER_LEN: usize = 7;
@@ -334,7 +333,7 @@ impl ModbusTcpConnection {
                 if let ModbusResponse::Exception { function, code } = response {
                     return Err(ModbusError::ExceptionResponse { function, code });
                 }
-                align_response_to_request(&pdu, response)
+                response.align_to_request(&pdu)
             }
         })
         .retry(backoff)


### PR DESCRIPTION
## Summary
- inline response alignment logic into `ModbusResponse::align_to_request`
- remove the public free response deserialization helper in favor of `ModbusResponse::deserialize`
- simplify crate-internal request serialization naming and keep public TCP ADU construction on `ModbusRequest::serialize`

## Why
These commits continue the API cleanup toward a more method-oriented Modbus request/response interface. They remove redundant helper layers, improve naming consistency, and make response validation and deserialization easier to discover from the owning types.

## Breaking changes
- removed `tiny_mb::response::deserialize_modbus_response`; callers should use `ModbusResponse::deserialize` instead

## Notes
- response validation/alignment now lives directly on `ModbusResponse`
- internal serializer naming is simplified without changing the public request serialization entry point