### PR TITLE
feat(tcp): add configurable Modbus TCP retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ serialized and a cancellation in one caller cannot interrupt a partially written
 Use `send_message_with_unit_id` or `with_unit_id(...)` when talking to multiple devices behind one
 Modbus TCP gateway.
 
-## Timeouts
+## Timeouts and retries
 
 `ModbusTcpConnection::new(...)` uses sensible defaults for connect, write, and read timeouts.
 The write timeout covers both sending the frame and flushing the socket. If you need custom limits,
@@ -92,7 +92,7 @@ construct the connection with `with_timeouts(...)`.
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
-use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpTimeouts};
+use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpRetry, ModbusTcpTimeouts};
 
 let connection = ModbusTcpConnection::with_timeouts(
     IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -104,8 +104,19 @@ let connection = ModbusTcpConnection::with_timeouts(
         write_timeout: Duration::from_secs(2),
         read_timeout: Duration::from_secs(2),
     },
-);
+)
+.with_retry(Some(ModbusTcpRetry {
+    initial_delay: Duration::from_millis(100),
+    max_elapsed: Duration::from_secs(1),
+    ..ModbusTcpRetry::default()
+}));
 ```
+
+By default, transient TCP connect/write/read failures are retried with exponential backoff starting
+at 500 ms, multiplied by 1.5, with jitter, and bounded only by `max_elapsed` (2 s). Set
+`max_times` to cap the number of retries as well. To disable same-call retry, pass
+`with_retry(None)`; the first transient error is returned to the caller for that call, but the
+connection state is still invalidated and the next call reconnects lazily.
 
 ## Error handling
 
@@ -117,6 +128,7 @@ Transport and protocol failures are reported with `ModbusError`, including:
 - transaction ID, protocol ID, and unit ID mismatches
 - request/response mismatches
 - request validation errors
+- invalid retry configuration as `ValidationError` (not retried)
 
 ## CLI example
 

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -13,6 +13,7 @@ pub mod adu;
 mod connected_state;
 mod frame;
 mod pending;
+mod retry;
 mod timeouts;
 mod writer;
 pub use adu::build_modbus_tcp_adu;

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -20,6 +20,6 @@ pub use adu::build_modbus_tcp_adu;
 
 /// Reusable Modbus TCP connection type.
 pub mod tcp_connection;
+pub use retry::ModbusTcpRetry;
 pub use tcp_connection::ModbusTcpConnection;
 pub use timeouts::ModbusTcpTimeouts;
-pub use retry::ModbusTcpRetry;

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -22,3 +22,4 @@ pub use adu::build_modbus_tcp_adu;
 pub mod tcp_connection;
 pub use tcp_connection::ModbusTcpConnection;
 pub use timeouts::ModbusTcpTimeouts;
+pub use retry::ModbusTcpRetry;

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -12,8 +12,28 @@ use crate::error::ModbusError;
 
 /// Exponential retry policy used by [`crate::tcp::ModbusTcpConnection`].
 ///
+/// The policy applies to one `send_message` or `send_message_with_unit_id` call.
+/// Each retry performs a fresh connect/write/read attempt after the connection
+/// has been invalidated by the transient failure that triggered the retry.
+///
 /// The [`Default::default`] policy starts at 500 ms, multiplies delays by
 /// 1.5, adds jitter, and retries until 2 s of total retry delay has elapsed.
+/// Set [`Self::max_times`] when you also need to cap the number of retry
+/// attempts. Pass `None` to [`crate::tcp::ModbusTcpConnection::with_retry`] to
+/// disable same-call retry entirely.
+///
+/// # Retried errors
+///
+/// Only errors classified as transient by [`ModbusError::is_transient`] are
+/// retried. Invalid retry configuration, request validation failures, protocol
+/// mismatches, Modbus exception responses, and request/response mismatches are
+/// returned immediately.
+///
+/// # Validation
+///
+/// A policy is validated when converted to the internal backoff builder, which
+/// happens before the send operation starts. Call [`Self::validate`] earlier if
+/// you want to fail fast while building configuration.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ModbusTcpRetry {
     /// Initial delay before the first retry attempt, in wall-clock time.

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -5,6 +5,10 @@
 
 use std::time::Duration;
 
+use backon::ExponentialBuilder;
+
+use crate::error::ModbusError;
+
 /// Exponential retry policy used by [`crate::tcp::ModbusTcpConnection`].
 ///
 /// The [`Default::default`] policy starts at 500 ms, multiplies delays by
@@ -37,6 +41,83 @@ pub struct ModbusTcpRetry {
     pub jitter: bool,
 }
 
+impl ModbusTcpRetry {
+    /// Validates this retry policy without starting a send operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModbusError::ValidationError`] when any field violates its
+    /// documented invariant.
+    pub fn validate(&self) -> Result<(), ModbusError> {
+        if self.initial_delay.is_zero() {
+            return Err(ModbusError::ValidationError(
+                "retry initial_delay must be > 0".to_string(),
+            ));
+        }
+
+        if self
+            .max_delay
+            .is_some_and(|max_delay| max_delay < self.initial_delay)
+        {
+            return Err(ModbusError::ValidationError(
+                "retry max_delay must be >= initial_delay".to_string(),
+            ));
+        }
+
+        if !self.multiplier.is_finite() || self.multiplier < 1.0 {
+            return Err(ModbusError::ValidationError(
+                "retry multiplier must be finite and >= 1.0".to_string(),
+            ));
+        }
+
+        if self.max_elapsed < self.initial_delay {
+            return Err(ModbusError::ValidationError(
+                "retry max_elapsed must be >= initial_delay".to_string(),
+            ));
+        }
+
+        if self.max_times.is_some_and(|max_times| max_times < 1) {
+            return Err(ModbusError::ValidationError(
+                "retry max_times must be >= 1".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Converts this policy to the internal backoff builder used by the send path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModbusError::ValidationError`] when any field violates its
+    /// documented invariant.
+    pub(crate) fn to_backoff(self) -> Result<ExponentialBuilder, ModbusError> {
+        self.validate()?;
+
+        let builder = ExponentialBuilder::default()
+            .with_min_delay(self.initial_delay)
+            .with_factor(self.multiplier)
+            .with_total_delay(Some(self.max_elapsed));
+        let builder = if let Some(max_delay) = self.max_delay {
+            builder.with_max_delay(max_delay)
+        } else {
+            builder
+        };
+        let builder = if self.jitter {
+            builder.with_jitter()
+        } else {
+            builder
+        };
+        let builder = if let Some(max_times) = self.max_times {
+            builder.with_max_times(max_times)
+        } else {
+            builder.without_max_times()
+        };
+
+        Ok(builder)
+    }
+}
+
 impl Default for ModbusTcpRetry {
     fn default() -> Self {
         Self {
@@ -54,6 +135,15 @@ impl Default for ModbusTcpRetry {
 mod tests {
     use super::*;
 
+    fn assert_validation_message(retry: ModbusTcpRetry, expected: &str) {
+        let error = retry.to_backoff().unwrap_err();
+
+        match error {
+            ModbusError::ValidationError(message) => assert_eq!(message, expected),
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
     #[test]
     fn retry_default_is_documented_policy() {
         let retry = ModbusTcpRetry::default();
@@ -64,5 +154,108 @@ mod tests {
         assert_eq!(retry.max_elapsed, Duration::from_secs(2));
         assert_eq!(retry.max_times, None);
         assert!(retry.jitter);
+    }
+
+    #[test]
+    fn to_backoff_rejects_zero_initial_delay() {
+        assert_validation_message(
+            ModbusTcpRetry {
+                initial_delay: Duration::ZERO,
+                ..ModbusTcpRetry::default()
+            },
+            "retry initial_delay must be > 0",
+        );
+    }
+
+    #[test]
+    fn to_backoff_rejects_max_delay_below_initial() {
+        assert_validation_message(
+            ModbusTcpRetry {
+                max_delay: Some(Duration::from_millis(1)),
+                ..ModbusTcpRetry::default()
+            },
+            "retry max_delay must be >= initial_delay",
+        );
+    }
+
+    #[test]
+    fn to_backoff_rejects_multiplier_below_one() {
+        assert_validation_message(
+            ModbusTcpRetry {
+                multiplier: 0.5,
+                ..ModbusTcpRetry::default()
+            },
+            "retry multiplier must be finite and >= 1.0",
+        );
+    }
+
+    #[test]
+    fn to_backoff_rejects_non_finite_multiplier() {
+        for multiplier in [f32::NAN, f32::INFINITY] {
+            assert_validation_message(
+                ModbusTcpRetry {
+                    multiplier,
+                    ..ModbusTcpRetry::default()
+                },
+                "retry multiplier must be finite and >= 1.0",
+            );
+        }
+    }
+
+    #[test]
+    fn to_backoff_rejects_max_elapsed_below_initial() {
+        assert_validation_message(
+            ModbusTcpRetry {
+                max_elapsed: Duration::from_millis(1),
+                ..ModbusTcpRetry::default()
+            },
+            "retry max_elapsed must be >= initial_delay",
+        );
+    }
+
+    #[test]
+    fn to_backoff_rejects_zero_max_times() {
+        assert_validation_message(
+            ModbusTcpRetry {
+                max_times: Some(0),
+                ..ModbusTcpRetry::default()
+            },
+            "retry max_times must be >= 1",
+        );
+    }
+
+    #[test]
+    fn to_backoff_accepts_unbounded_max_times() {
+        ModbusTcpRetry {
+            max_times: None,
+            ..ModbusTcpRetry::default()
+        }
+        .to_backoff()
+        .unwrap();
+    }
+
+    #[test]
+    fn to_backoff_accepts_default() {
+        ModbusTcpRetry::default().to_backoff().unwrap();
+    }
+
+    #[test]
+    fn validate_accepts_default() {
+        ModbusTcpRetry::default().validate().unwrap();
+    }
+
+    #[test]
+    fn to_backoff_default_matches_documented_chain() {
+        let expected = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(500))
+            .with_factor(1.5)
+            .with_jitter()
+            .with_total_delay(Some(Duration::from_secs(2)))
+            .without_max_times();
+
+        assert_eq!(
+            format!("{:?}", ModbusTcpRetry::default().to_backoff().unwrap()),
+            format!("{expected:?}")
+        );
     }
 }

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 tinymb contributors
+
+//! Retry configuration for Modbus TCP send operations.
+
+use std::time::Duration;
+
+/// Exponential retry policy used by [`crate::tcp::ModbusTcpConnection`].
+///
+/// The [`Default::default`] policy starts at 500 ms, multiplies delays by
+/// 1.5, adds jitter, and retries until 2 s of total retry delay has elapsed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ModbusTcpRetry {
+    /// Initial delay before the first retry attempt, in wall-clock time.
+    ///
+    /// Must be greater than zero.
+    pub initial_delay: Duration,
+    /// Optional maximum delay for an individual retry sleep, in wall-clock time.
+    ///
+    /// When set, this must be greater than or equal to [`Self::initial_delay`].
+    /// `None` leaves individual sleeps uncapped.
+    pub max_delay: Option<Duration>,
+    /// Multiplier applied to each subsequent retry delay.
+    ///
+    /// Must be finite and greater than or equal to `1.0`.
+    pub multiplier: f32,
+    /// Maximum total retry delay for one send call, in wall-clock time.
+    ///
+    /// Must be greater than or equal to [`Self::initial_delay`].
+    pub max_elapsed: Duration,
+    /// Optional cap on the number of retries within one send call.
+    ///
+    /// When set, this must be greater than or equal to `1`. `None` means retry
+    /// count is unbounded and governed only by [`Self::max_elapsed`].
+    pub max_times: Option<usize>,
+    /// Whether to add jitter to retry sleeps.
+    pub jitter: bool,
+}
+
+impl Default for ModbusTcpRetry {
+    fn default() -> Self {
+        Self {
+            initial_delay: Duration::from_millis(500),
+            max_delay: None,
+            multiplier: 1.5,
+            max_elapsed: Duration::from_secs(2),
+            max_times: None,
+            jitter: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_default_is_documented_policy() {
+        let retry = ModbusTcpRetry::default();
+
+        assert_eq!(retry.initial_delay, Duration::from_millis(500));
+        assert_eq!(retry.max_delay, None);
+        assert_eq!(retry.multiplier, 1.5);
+        assert_eq!(retry.max_elapsed, Duration::from_secs(2));
+        assert_eq!(retry.max_times, None);
+        assert!(retry.jitter);
+    }
+}

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -3,9 +3,10 @@
 
 //! Retry configuration for Modbus TCP send operations.
 
+use std::future::Future;
 use std::time::Duration;
 
-use backon::ExponentialBuilder;
+use backon::{ExponentialBuilder, Retryable};
 
 use crate::error::ModbusError;
 
@@ -118,6 +119,20 @@ impl ModbusTcpRetry {
     }
 }
 
+pub(crate) async fn retry_transient<Operation, Fut, T>(
+    operation: Operation,
+    retry: ModbusTcpRetry,
+) -> Result<T, ModbusError>
+where
+    Operation: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, ModbusError>>,
+{
+    operation
+        .retry(retry.to_backoff()?)
+        .when(ModbusError::is_transient)
+        .await
+}
+
 impl Default for ModbusTcpRetry {
     fn default() -> Self {
         Self {
@@ -132,6 +147,7 @@ impl Default for ModbusTcpRetry {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp, clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -12,7 +12,6 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use backon::Retryable;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -21,7 +20,7 @@ use tracing::debug;
 use crate::tcp::connected_state::ConnectedState;
 use crate::tcp::frame::MBAP_HEADER_LEN;
 use crate::tcp::pending::{self, PendingGuard};
-use crate::tcp::retry::ModbusTcpRetry;
+use crate::tcp::retry::{ModbusTcpRetry, retry_transient};
 use crate::tcp::timeouts::ModbusTcpTimeouts;
 use crate::tcp::writer::{self, TearDown};
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError, tcp::adu::build_modbus_tcp_adu};
@@ -36,6 +35,14 @@ type SharedConnectedState = Arc<Mutex<Option<Arc<ConnectedState>>>>;
 /// caller waiting on the matching MBAP transaction identifier. A generation
 /// counter prevents stale read/write failures from tearing down a newer socket
 /// after a reconnect.
+///
+/// # Retries
+///
+/// Transient connect, write, and read failures are retried within a send call
+/// according to [`Self::with_retry`] and [`ModbusTcpRetry`]. Passing `None` to
+/// [`Self::with_retry`] disables same-call retry and returns the first transient
+/// error, but reconnect remains independent: the failed socket is invalidated
+/// and the next call reconnects lazily.
 #[derive(Clone, Debug)]
 pub struct ModbusTcpConnection {
     state: SharedConnectedState,
@@ -430,17 +437,17 @@ impl ModbusTcpConnection {
         match self.retry {
             None => self.send_message_attempt(unit_id, pdu).await,
             Some(retry) => {
-                let backoff = retry.to_backoff()?;
                 let connection = self.clone();
                 let pdu = pdu.clone();
 
-                (|| {
-                    let connection = connection.clone();
-                    let pdu = pdu.clone();
-                    async move { connection.send_message_attempt(unit_id, &pdu).await }
-                })
-                .retry(backoff)
-                .when(ModbusError::is_transient)
+                retry_transient(
+                    || {
+                        let connection = connection.clone();
+                        let pdu = pdu.clone();
+                        async move { connection.send_message_attempt(unit_id, &pdu).await }
+                    },
+                    retry,
+                )
                 .await
             }
         }

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -116,7 +116,16 @@ impl ModbusTcpConnection {
         }
     }
 
-    /// Configures the retry policy used for future send operations.
+    /// Configures the retry policy used for future send operations on this handle.
+    ///
+    /// Retry configuration is stored on the handle, while the underlying socket is
+    /// shared between clones. Calling this method does not mutate existing clones;
+    /// clone or derive `with_unit_id` handles after setting the policy when they
+    /// should use the same retry behavior.
+    ///
+    /// The policy is validated when a send operation starts. Use
+    /// [`ModbusTcpRetry::validate`] if you need to reject invalid configuration
+    /// before storing it on the connection.
     ///
     /// # Arguments
     ///
@@ -136,7 +145,7 @@ impl ModbusTcpConnection {
     /// # Returns
     ///
     /// Returns `Some(policy)` when same-call retry is enabled, or `None` when a
-    /// transient failure is returned after the first attempt.
+    /// transient failure is returned after the first attempt without retrying.
     #[must_use]
     pub fn retry(&self) -> Option<ModbusTcpRetry> {
         self.retry
@@ -172,7 +181,7 @@ impl ModbusTcpConnection {
     /// # Returns
     ///
     /// Returns a clone-like handle with the same socket, transaction-id counter,
-    /// timeout configuration, and generation state as `self`.
+    /// timeout configuration, retry policy, and generation state as `self`.
     #[must_use]
     pub fn with_unit_id(&self, unit_id: u8) -> Self {
         Self {
@@ -388,9 +397,10 @@ impl ModbusTcpConnection {
     /// Sends one request using this connection's default unit id.
     ///
     /// The connection is opened on demand. Transient connect, read, and write
-    /// failures invalidate the current socket and are retried with a short
-    /// exponential backoff. Protocol, validation, and request/response mismatch
-    /// failures are returned without retrying.
+    /// failures invalidate the current socket and are retried according to this
+    /// handle's [`ModbusTcpRetry`] policy. Protocol, validation, Modbus
+    /// exception, and request/response mismatch failures are returned without
+    /// retrying.
     ///
     /// # Arguments
     ///
@@ -414,6 +424,7 @@ impl ModbusTcpConnection {
     /// This is useful when one TCP gateway fronts multiple logical Modbus devices.
     /// The socket and transaction-id counter are shared with the default-unit-id
     /// path, so calls for different unit ids may be in flight concurrently.
+    /// Retry and reconnect semantics match [`Self::send_message`].
     ///
     /// # Arguments
     ///

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -12,7 +12,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use backon::{ExponentialBuilder, Retryable};
+use backon::Retryable;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -21,11 +21,11 @@ use tracing::debug;
 use crate::tcp::connected_state::ConnectedState;
 use crate::tcp::frame::MBAP_HEADER_LEN;
 use crate::tcp::pending::{self, PendingGuard};
+use crate::tcp::retry::ModbusTcpRetry;
 use crate::tcp::timeouts::ModbusTcpTimeouts;
 use crate::tcp::writer::{self, TearDown};
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError, tcp::adu::build_modbus_tcp_adu};
 
-const RETRY_MAX_ELAPSED_TIME: Duration = Duration::from_secs(2);
 type SharedConnectedState = Arc<Mutex<Option<Arc<ConnectedState>>>>;
 
 /// Reusable Modbus TCP client handle.
@@ -44,6 +44,7 @@ pub struct ModbusTcpConnection {
     unit_id: u8,
     transaction_id: Arc<AtomicU16>,
     timeouts: ModbusTcpTimeouts,
+    retry: Option<ModbusTcpRetry>,
     generation: Arc<AtomicU64>,
 }
 
@@ -103,8 +104,35 @@ impl ModbusTcpConnection {
             unit_id,
             transaction_id: Arc::new(AtomicU16::new(transaction_id)),
             timeouts,
+            retry: Some(ModbusTcpRetry::default()),
             generation: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Configures the retry policy used for future send operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `retry` - Retry policy to use. Pass `None` to disable same-call retry.
+    ///
+    /// # Returns
+    ///
+    /// Returns this handle with the updated retry policy.
+    #[must_use]
+    pub fn with_retry(mut self, retry: Option<ModbusTcpRetry>) -> Self {
+        self.retry = retry;
+        self
+    }
+
+    /// Returns the retry policy used for future send operations.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(policy)` when same-call retry is enabled, or `None` when a
+    /// transient failure is returned after the first attempt.
+    #[must_use]
+    pub fn retry(&self) -> Option<ModbusTcpRetry> {
+        self.retry
     }
 
     /// Returns the timeout configuration used for future operations.
@@ -147,6 +175,7 @@ impl ModbusTcpConnection {
             unit_id,
             transaction_id: Arc::clone(&self.transaction_id),
             timeouts: self.timeouts,
+            retry: self.retry,
             generation: Arc::clone(&self.generation),
         }
     }
@@ -266,17 +295,6 @@ impl ModbusTcpConnection {
             .await
             .as_ref()
             .is_some_and(|state| !state.reader_task.is_finished())
-    }
-
-    /// Returns the exponential backoff policy used to retry transient I/O failures.
-    ///
-    /// The total time spent retrying is capped by [`RETRY_MAX_ELAPSED_TIME`].
-    fn retry_backoff() -> ExponentialBuilder {
-        ExponentialBuilder::default()
-            .with_min_delay(Duration::from_millis(500))
-            .with_factor(1.5)
-            .with_jitter()
-            .with_total_delay(Some(RETRY_MAX_ELAPSED_TIME))
     }
 
     async fn send_message_attempt(
@@ -409,18 +427,23 @@ impl ModbusTcpConnection {
         unit_id: u8,
         pdu: &ModbusRequest,
     ) -> Result<ModbusResponse, ModbusError> {
-        let backoff = Self::retry_backoff();
-        let connection = self.clone();
-        let pdu = pdu.clone();
+        match self.retry {
+            None => self.send_message_attempt(unit_id, pdu).await,
+            Some(retry) => {
+                let backoff = retry.to_backoff()?;
+                let connection = self.clone();
+                let pdu = pdu.clone();
 
-        (|| {
-            let connection = connection.clone();
-            let pdu = pdu.clone();
-            async move { connection.send_message_attempt(unit_id, &pdu).await }
-        })
-        .retry(backoff)
-        .when(ModbusError::is_transient)
-        .await
+                (|| {
+                    let connection = connection.clone();
+                    let pdu = pdu.clone();
+                    async move { connection.send_message_attempt(unit_id, &pdu).await }
+                })
+                .retry(backoff)
+                .when(ModbusError::is_transient)
+                .await
+            }
+        }
     }
 }
 
@@ -443,20 +466,31 @@ mod tests {
     }
 
     #[test]
-    fn retry_backoff_builds_without_panicking() {
-        let _ = ModbusTcpConnection::retry_backoff();
-    }
-
-    #[test]
-    fn retry_max_elapsed_time_is_two_seconds() {
-        assert_eq!(RETRY_MAX_ELAPSED_TIME, Duration::from_secs(2));
-    }
-
-    #[test]
     fn new_connection_uses_default_timeouts() {
         let connection = ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0);
 
         assert_eq!(connection.timeouts(), ModbusTcpTimeouts::default());
+    }
+
+    #[test]
+    fn connection_with_retry_none_disables_retry() {
+        let connection =
+            ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0).with_retry(None);
+
+        assert_eq!(connection.retry(), None);
+    }
+
+    #[test]
+    fn with_timeouts_preserves_default_retry() {
+        let connection = ModbusTcpConnection::with_timeouts(
+            "127.0.0.1".parse().unwrap(),
+            502,
+            1,
+            0,
+            ModbusTcpTimeouts::default(),
+        );
+
+        assert_eq!(connection.retry(), Some(ModbusTcpRetry::default()));
     }
 
     #[test]
@@ -487,6 +521,20 @@ mod tests {
             &connection.transaction_id,
             &child.transaction_id,
         ));
+    }
+
+    #[test]
+    fn with_unit_id_propagates_retry_config() {
+        let retry = ModbusTcpRetry {
+            initial_delay: Duration::from_millis(10),
+            ..ModbusTcpRetry::default()
+        };
+        let connection = ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 7)
+            .with_retry(Some(retry));
+
+        let child = connection.with_unit_id(42);
+
+        assert_eq!(child.retry(), Some(retry));
     }
 
     #[tokio::test]

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -279,6 +279,87 @@ impl ModbusTcpConnection {
             .with_total_delay(Some(RETRY_MAX_ELAPSED_TIME))
     }
 
+    async fn send_message_attempt(
+        &self,
+        unit_id: u8,
+        pdu: &ModbusRequest,
+    ) -> Result<ModbusResponse, ModbusError> {
+        let state = self.ensure_connected_state().await?;
+        let captured_generation = state.generation;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let tid = pending::allocate_transaction_id(&self.transaction_id, &state.pending, tx)?;
+        let mut pending_guard = PendingGuard {
+            pending: Arc::clone(&state.pending),
+            tid,
+            armed: true,
+        };
+
+        let adu = build_modbus_tcp_adu(tid, unit_id, pdu)?;
+        debug!(tid, "Modbus TCP Frame: {:02X?}", adu);
+
+        writer::write_adu_cancellation_safe(
+            Arc::clone(&state.writer),
+            adu,
+            self.timeouts.write_timeout,
+            TearDown {
+                connection: self.clone(),
+                generation: captured_generation,
+            },
+        )
+        .await?;
+
+        let response_buffer = match timeout(self.timeouts.read_timeout, rx).await {
+            Ok(Ok(Ok(frame))) => frame,
+            Ok(Ok(Err(error))) => {
+                self.invalidate(Some(captured_generation)).await;
+                return Err(error);
+            }
+            Ok(Err(_)) => {
+                self.invalidate(Some(captured_generation)).await;
+                return Err(ModbusError::ReadError(io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    "reader task terminated",
+                )));
+            }
+            Err(_) => {
+                self.invalidate(Some(captured_generation)).await;
+                return Err(ModbusError::ReadTimeout);
+            }
+        };
+
+        pending_guard.disarm();
+
+        let protocol_id = u16::from_be_bytes([response_buffer[2], response_buffer[3]]);
+        if protocol_id != 0 {
+            return Err(ModbusError::ProtocolIdMismatch {
+                actual: protocol_id,
+            });
+        }
+
+        let received_unit_id = response_buffer[6];
+        if received_unit_id != unit_id {
+            return Err(ModbusError::UnitIdMismatch {
+                expected: unit_id,
+                actual: received_unit_id,
+            });
+        }
+
+        let received_transaction_id = u16::from_be_bytes([response_buffer[0], response_buffer[1]]);
+        if received_transaction_id != tid {
+            return Err(ModbusError::TransactionIdMismatch {
+                expected: tid,
+                actual: received_transaction_id,
+            });
+        }
+
+        let pdu_bytes = &response_buffer[MBAP_HEADER_LEN..];
+        let response = ModbusResponse::try_from(pdu_bytes)?;
+        if let ModbusResponse::Exception { function, code } = response {
+            return Err(ModbusError::ExceptionResponse { function, code });
+        }
+        response.align_to_request(pdu)
+    }
+
     /// Sends one request using this connection's default unit id.
     ///
     /// The connection is opened on demand. Transient connect, read, and write
@@ -335,87 +416,7 @@ impl ModbusTcpConnection {
         (|| {
             let connection = connection.clone();
             let pdu = pdu.clone();
-            async move {
-                let state = connection.ensure_connected_state().await?;
-                let captured_generation = state.generation;
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let tid = pending::allocate_transaction_id(
-                    &connection.transaction_id,
-                    &state.pending,
-                    tx,
-                )?;
-                let mut pending_guard = PendingGuard {
-                    pending: Arc::clone(&state.pending),
-                    tid,
-                    armed: true,
-                };
-
-                let adu = build_modbus_tcp_adu(tid, unit_id, &pdu)?;
-                debug!(tid, "Modbus TCP Frame: {:02X?}", adu);
-
-                writer::write_adu_cancellation_safe(
-                    Arc::clone(&state.writer),
-                    adu,
-                    connection.timeouts.write_timeout,
-                    TearDown {
-                        connection: connection.clone(),
-                        generation: captured_generation,
-                    },
-                )
-                .await?;
-
-                let response_buffer = match timeout(connection.timeouts.read_timeout, rx).await {
-                    Ok(Ok(Ok(frame))) => frame,
-                    Ok(Ok(Err(error))) => {
-                        connection.invalidate(Some(captured_generation)).await;
-                        return Err(error);
-                    }
-                    Ok(Err(_)) => {
-                        connection.invalidate(Some(captured_generation)).await;
-                        return Err(ModbusError::ReadError(io::Error::new(
-                            io::ErrorKind::ConnectionAborted,
-                            "reader task terminated",
-                        )));
-                    }
-                    Err(_) => {
-                        connection.invalidate(Some(captured_generation)).await;
-                        return Err(ModbusError::ReadTimeout);
-                    }
-                };
-
-                pending_guard.disarm();
-
-                let protocol_id = u16::from_be_bytes([response_buffer[2], response_buffer[3]]);
-                if protocol_id != 0 {
-                    return Err(ModbusError::ProtocolIdMismatch {
-                        actual: protocol_id,
-                    });
-                }
-
-                let received_unit_id = response_buffer[6];
-                if received_unit_id != unit_id {
-                    return Err(ModbusError::UnitIdMismatch {
-                        expected: unit_id,
-                        actual: received_unit_id,
-                    });
-                }
-
-                let received_transaction_id =
-                    u16::from_be_bytes([response_buffer[0], response_buffer[1]]);
-                if received_transaction_id != tid {
-                    return Err(ModbusError::TransactionIdMismatch {
-                        expected: tid,
-                        actual: received_transaction_id,
-                    });
-                }
-
-                let pdu_bytes = &response_buffer[MBAP_HEADER_LEN..];
-                let response = ModbusResponse::try_from(pdu_bytes)?;
-                if let ModbusResponse::Exception { function, code } = response {
-                    return Err(ModbusError::ExceptionResponse { function, code });
-                }
-                response.align_to_request(&pdu)
-            }
+            async move { connection.send_message_attempt(unit_id, &pdu).await }
         })
         .retry(backoff)
         .when(ModbusError::is_transient)

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -258,7 +258,8 @@ async fn server_disconnects_on_write() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+        .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -320,7 +321,8 @@ async fn server_disconnects_on_header_read() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+        .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -524,7 +526,8 @@ async fn send_message_returns_read_timeout_from_slow_server() {
             write_timeout: Duration::from_millis(50),
             read_timeout: Duration::from_millis(25),
         },
-    );
+    )
+    .with_retry(None);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -12,7 +12,8 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
@@ -20,7 +21,7 @@ use tokio::sync::Mutex;
 mod support;
 
 use tiny_mb::ModbusError;
-use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpTimeouts};
+use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpRetry, ModbusTcpTimeouts};
 use tiny_mb::{ModbusRequest, ModbusResponse};
 
 use support::{
@@ -49,6 +50,17 @@ fn make_read_coils_response(tid: u16, unit_id: u8, coils: &[bool]) -> Vec<u8> {
         pdu.push(byte);
     }
     build_tcp_response_frame(tid, unit_id, &pdu)
+}
+
+fn fast_retry(max_elapsed: Duration, max_times: Option<usize>) -> ModbusTcpRetry {
+    ModbusTcpRetry {
+        initial_delay: Duration::from_millis(5),
+        max_delay: Some(Duration::from_millis(10)),
+        multiplier: 1.1,
+        max_elapsed,
+        max_times,
+        jitter: false,
+    }
 }
 
 fn make_write_single_register_response(tid: u16, unit_id: u8, address: u16, value: u16) -> Vec<u8> {
@@ -661,4 +673,148 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
             coils: vec![true, false]
         }
     );
+}
+
+#[tokio::test]
+async fn send_message_with_disabled_retry_does_not_retry() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accepts = Arc::new(AtomicU8::new(0));
+
+    tokio::spawn({
+        let accepts = Arc::clone(&accepts);
+        async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            accepts.fetch_add(1, Ordering::SeqCst);
+            drop(stream);
+        }
+    });
+
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0).with_retry(None);
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let error = conn.send_message(&request).await.unwrap_err();
+
+    assert!(error.is_transient());
+    assert_eq!(accepts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn disabled_retry_still_reconnects_on_next_call() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(stream);
+
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_request_frame(&mut stream).await.unwrap();
+        let response = make_read_coils_response(request.transaction_id, request.unit_id, &[true]);
+        stream.write_all(&response).await.unwrap();
+    });
+
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0).with_retry(None);
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    assert!(
+        conn.send_message(&request)
+            .await
+            .unwrap_err()
+            .is_transient()
+    );
+    let response = conn.send_message(&request).await.unwrap();
+
+    assert_eq!(response, ModbusResponse::ReadCoils { coils: vec![true] });
+}
+
+#[tokio::test]
+async fn send_message_with_custom_retry_honors_max_elapsed() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            drop(stream);
+        }
+    });
+
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+        .with_retry(Some(fast_retry(Duration::from_millis(100), None)));
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let started = Instant::now();
+    let error = conn.send_message(&request).await.unwrap_err();
+
+    assert!(error.is_transient());
+    assert!(started.elapsed() < Duration::from_millis(250));
+}
+
+#[tokio::test]
+async fn send_message_with_max_times_caps_attempts() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accepts = Arc::new(AtomicU8::new(0));
+
+    tokio::spawn({
+        let accepts = Arc::clone(&accepts);
+        async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                accepts.fetch_add(1, Ordering::SeqCst);
+                drop(stream);
+            }
+        }
+    });
+
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+        .with_retry(Some(fast_retry(Duration::from_secs(5), Some(2))));
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let started = Instant::now();
+    let error = conn.send_message(&request).await.unwrap_err();
+
+    assert!(error.is_transient());
+    assert_eq!(accepts.load(Ordering::SeqCst), 3);
+    assert!(started.elapsed() < Duration::from_millis(250));
+}
+
+#[tokio::test]
+async fn invalid_retry_policy_surfaces_as_validation_error() {
+    let conn = ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0).with_retry(Some(
+        ModbusTcpRetry {
+            initial_delay: Duration::ZERO,
+            ..ModbusTcpRetry::default()
+        },
+    ));
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let error = conn.send_message(&request).await.unwrap_err();
+
+    match error {
+        ModbusError::ValidationError(message) => {
+            assert_eq!(message, "retry initial_delay must be > 0");
+        }
+        other => panic!("Expected ValidationError, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary
- introduce a public `ModbusTcpRetry` type for configurable TCP retry behavior
- wire retry configuration into `ModbusTcpConnection`
- add backoff validation and conversion logic
- re-export retry configuration from the `tcp` module
- expand tests for disabled, custom, invalid, and reconnect retry behavior
- document retry policy and reconnect semantics

## Why
This adds first-class control over transient Modbus TCP retry behavior so callers can tune resilience and reconnect handling without relying on fixed internal behavior.

## Testing
- added coverage for retry configuration and reconnect scenarios
- updated transient-error tests to use a fast retry police