### PR TITLE
refactor(api): simplify public API surface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@ pub mod error;
 pub use error::ModbusError;
 
 /// Typed Modbus request PDUs and serialization.
-pub mod request;
+mod request;
 pub use request::ModbusRequest;
 
 /// Typed Modbus response PDUs and deserialization.
-pub mod response;
+mod response;
 pub use response::ModbusResponse;
 
 pub mod tcp;

--- a/src/request.rs
+++ b/src/request.rs
@@ -144,7 +144,7 @@ impl ModbusRequest {
     /// # Errors
     ///
     /// Returns [`ModbusError::ValidationError`] when the request violates Modbus limits.
-    pub fn serialize(&self) -> Result<Vec<u8>, ModbusError> {
+    pub(crate) fn serialize(&self) -> Result<Vec<u8>, ModbusError> {
         self.validate()?;
         serialize_modbus_request(self)
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,11 +6,7 @@ use std::convert::TryFrom;
 use crate::ModbusRequest;
 use crate::error::ModbusError;
 
-fn unpack_bits(
-    response: &[u8],
-    min_len: usize,
-    exact_count: Option<usize>,
-) -> Result<(usize, Vec<bool>), ModbusError> {
+fn unpack_bits(response: &[u8], min_len: usize) -> Result<Vec<bool>, ModbusError> {
     if response.len() < min_len {
         return Err(ModbusError::DeserializationError(format!(
             "Invalid response: expected at least {} bytes, got {}",
@@ -33,10 +29,7 @@ fn unpack_bits(
             result.push((byte >> bit) & 1 == 1);
         }
     }
-    if let Some(count) = exact_count {
-        result.truncate(count);
-    }
-    Ok((byte_count, result))
+    Ok(result)
 }
 
 fn parse_registers(response: &[u8], min_len: usize) -> Result<Vec<u16>, ModbusError> {
@@ -130,27 +123,6 @@ pub enum ModbusResponse {
 }
 
 impl ModbusResponse {
-    /// Deserializes a Modbus response PDU.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ModbusError::DeserializationError`] when the bytes are not a supported response.
-    pub fn deserialize(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
-        deserialize_modbus_response(response, None)
-    }
-
-    /// Deserializes a Modbus response PDU and truncates bit-packed reads to `count` values.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ModbusError::DeserializationError`] when the bytes are not a supported response.
-    pub fn deserialize_with_count(
-        response: &[u8],
-        count: usize,
-    ) -> Result<ModbusResponse, ModbusError> {
-        deserialize_modbus_response(response, Some(count))
-    }
-
     /// Aligns this response with the request that produced it.
     ///
     /// # Arguments
@@ -315,10 +287,7 @@ impl ModbusResponse {
     }
 }
 
-fn deserialize_modbus_response(
-    response: &[u8],
-    bit_count: Option<usize>,
-) -> Result<ModbusResponse, ModbusError> {
+fn deserialize_modbus_response(response: &[u8]) -> Result<ModbusResponse, ModbusError> {
     if response.is_empty() {
         return Err(ModbusError::DeserializationError(
             "Empty response".to_string(),
@@ -328,11 +297,11 @@ fn deserialize_modbus_response(
     let function_code = response[0];
     match function_code {
         1 => {
-            let (_, coils) = unpack_bits(response, 2, bit_count)?;
+            let coils = unpack_bits(response, 2)?;
             Ok(ModbusResponse::ReadCoils { coils })
         }
         2 => {
-            let (_, inputs) = unpack_bits(response, 2, bit_count)?;
+            let inputs = unpack_bits(response, 2)?;
             Ok(ModbusResponse::ReadDiscreteInputs { inputs })
         }
         3 => {
@@ -424,7 +393,7 @@ impl TryFrom<&[u8]> for ModbusResponse {
     type Error = ModbusError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        ModbusResponse::deserialize(bytes)
+        deserialize_modbus_response(bytes)
     }
 }
 
@@ -445,7 +414,7 @@ mod tests {
     fn test_deserialize_read_coils() {
         let response = vec![1u8, 1u8, 0x25];
         let expected_coils = vec![true, false, true, false, false, true, false, false];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadCoils {
@@ -458,7 +427,7 @@ mod tests {
     fn test_deserialize_read_discrete_inputs() {
         let response = vec![2u8, 1u8, 0xAA];
         let expected_inputs = vec![false, true, false, true, false, true, false, true];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadDiscreteInputs {
@@ -471,7 +440,7 @@ mod tests {
     fn test_deserialize_read_holding_registers() {
         let response = vec![3u8, 4u8, 0x01, 0x02, 0x03, 0x04];
         let expected_registers = vec![0x0102, 0x0304];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadHoldingRegisters {
@@ -484,7 +453,7 @@ mod tests {
     fn test_deserialize_read_input_registers() {
         let response = vec![4u8, 2u8, 0xAB, 0xCD];
         let expected_registers = vec![0xABCD];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::ReadInputRegisters {
@@ -496,7 +465,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_coil_true() {
         let response = vec![5u8, 0x00, 0x10, 0xFF, 0x00];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleCoil {
@@ -509,7 +478,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_coil_false() {
         let response = vec![5u8, 0x00, 0x10, 0x00, 0x00];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleCoil {
@@ -522,7 +491,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_register() {
         let response = vec![6u8, 0x00, 0x10, 0x12, 0x34];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteSingleRegister {
@@ -535,7 +504,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_multiple_coils() {
         let response = vec![15u8, 0x00, 0x01, 0x00, 0x06];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteMultipleCoils {
@@ -548,7 +517,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_multiple_registers() {
         let response = vec![16u8, 0x00, 0x01, 0x00, 0x02];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::WriteMultipleRegisters {
@@ -561,7 +530,7 @@ mod tests {
     #[test]
     fn test_deserialize_exception() {
         let response = vec![0x81u8, 0x02];
-        let result = ModbusResponse::deserialize(&response).unwrap();
+        let result = ModbusResponse::try_from(response.as_slice()).unwrap();
         assert_eq!(
             result,
             ModbusResponse::Exception {
@@ -574,14 +543,14 @@ mod tests {
     #[test]
     fn test_invalid_response_empty() {
         let response = vec![];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_invalid_response_too_short_for_registers() {
         let response = vec![3u8, 1u8];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 
@@ -804,7 +773,7 @@ mod tests {
     #[test]
     fn test_deserialize_unsupported_function_code() {
         let response = vec![7u8];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -817,7 +786,7 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_coil_invalid_value() {
         let response = vec![5u8, 0x00, 0x10, 0x01, 0x00];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -830,7 +799,7 @@ mod tests {
     #[test]
     fn test_deserialize_read_holding_registers_odd_byte_count() {
         let response = vec![3u8, 3u8, 0x01, 0x02, 0x03];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -843,7 +812,7 @@ mod tests {
     #[test]
     fn test_deserialize_read_coils_response_too_short_for_byte_count() {
         let response = vec![1u8, 5u8, 0x01, 0x02];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -856,7 +825,7 @@ mod tests {
     #[test]
     fn test_deserialize_read_holding_registers_response_too_short_for_byte_count() {
         let response = vec![3u8, 4u8, 0x01, 0x02];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
         match result.unwrap_err() {
             ModbusError::DeserializationError(msg) => {
@@ -869,35 +838,35 @@ mod tests {
     #[test]
     fn test_deserialize_write_single_coil_too_short() {
         let response = vec![5u8, 0x00, 0x10, 0xFF];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_write_single_register_too_short() {
         let response = vec![6u8, 0x00, 0x10, 0x12];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_write_multiple_coils_too_short() {
         let response = vec![15u8, 0x00, 0x01, 0x00];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_write_multiple_registers_too_short() {
         let response = vec![16u8, 0x00, 0x01, 0x00];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_deserialize_exception_too_short() {
         let response = vec![0x81u8];
-        let result = ModbusResponse::deserialize(&response);
+        let result = ModbusResponse::try_from(response.as_slice());
         assert!(result.is_err());
     }
 

--- a/src/tcp/adu.rs
+++ b/src/tcp/adu.rs
@@ -26,7 +26,7 @@ const MBAP_HEADER_LEN: usize = 7;
 /// # Errors
 /// Returns a [`ModbusError`] if the request cannot be serialized or the
 /// resulting frame would exceed the Modbus TCP length field.
-pub fn build_modbus_tcp_adu(
+pub(crate) fn build_modbus_tcp_adu(
     transaction_id: u16,
     unit_id: u8,
     pdu: &ModbusRequest,

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -3,23 +3,20 @@
 
 //! Modbus TCP framing and transport helpers.
 //!
-//! The public surface exports ADU construction plus the reusable connection
-//! handle and timeout configuration. Internal submodules keep MBAP frame
-//! parsing, connected-state reader lifecycle, pending request tracking, and
+//! The public surface exports the reusable connection handle plus its retry and
+//! timeout configuration. Internal submodules keep ADU/MBAP frame construction,
+//! connected-state reader lifecycle, pending request tracking, and
 //! cancellation-safe writes separated by concern.
 
-/// Modbus TCP ADU frame construction.
-pub mod adu;
+mod adu;
 mod connected_state;
 mod frame;
 mod pending;
 mod retry;
 mod timeouts;
 mod writer;
-pub use adu::build_modbus_tcp_adu;
 
-/// Reusable Modbus TCP connection type.
-pub mod tcp_connection;
+mod tcp_connection;
 pub use retry::ModbusTcpRetry;
 pub use tcp_connection::ModbusTcpConnection;
 pub use timeouts::ModbusTcpTimeouts;

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -140,37 +140,6 @@ impl ModbusTcpConnection {
         self
     }
 
-    /// Returns the retry policy used for future send operations.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Some(policy)` when same-call retry is enabled, or `None` when a
-    /// transient failure is returned after the first attempt without retrying.
-    #[must_use]
-    pub fn retry(&self) -> Option<ModbusTcpRetry> {
-        self.retry
-    }
-
-    /// Returns the timeout configuration used for future operations.
-    ///
-    /// # Returns
-    ///
-    /// Returns the connect, write, and read timeouts stored on this handle.
-    #[must_use]
-    pub fn timeouts(&self) -> ModbusTcpTimeouts {
-        self.timeouts
-    }
-
-    /// Returns the default unit identifier used by [`Self::send_message`].
-    ///
-    /// # Returns
-    ///
-    /// Returns the unit id configured for this handle.
-    #[must_use]
-    pub fn unit_id(&self) -> u8 {
-        self.unit_id
-    }
-
     /// Returns a new handle that shares the same transport but overrides the default unit id.
     ///
     /// # Arguments
@@ -487,7 +456,7 @@ mod tests {
     fn new_connection_uses_default_timeouts() {
         let connection = ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0);
 
-        assert_eq!(connection.timeouts(), ModbusTcpTimeouts::default());
+        assert_eq!(connection.timeouts, ModbusTcpTimeouts::default());
     }
 
     #[test]
@@ -495,7 +464,7 @@ mod tests {
         let connection =
             ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0).with_retry(None);
 
-        assert_eq!(connection.retry(), None);
+        assert_eq!(connection.retry, None);
     }
 
     #[test]
@@ -508,7 +477,7 @@ mod tests {
             ModbusTcpTimeouts::default(),
         );
 
-        assert_eq!(connection.retry(), Some(ModbusTcpRetry::default()));
+        assert_eq!(connection.retry, Some(ModbusTcpRetry::default()));
     }
 
     #[test]
@@ -522,7 +491,7 @@ mod tests {
         let connection =
             ModbusTcpConnection::with_timeouts("127.0.0.1".parse().unwrap(), 502, 1, 0, timeouts);
 
-        assert_eq!(connection.timeouts(), timeouts);
+        assert_eq!(connection.timeouts, timeouts);
     }
 
     #[test]
@@ -531,9 +500,9 @@ mod tests {
 
         let child = connection.with_unit_id(42);
 
-        assert_eq!(connection.unit_id(), 1);
-        assert_eq!(child.unit_id(), 42);
-        assert_eq!(child.timeouts(), connection.timeouts());
+        assert_eq!(connection.unit_id, 1);
+        assert_eq!(child.unit_id, 42);
+        assert_eq!(child.timeouts, connection.timeouts);
         assert!(Arc::ptr_eq(&connection.state, &child.state));
         assert!(Arc::ptr_eq(
             &connection.transaction_id,
@@ -552,7 +521,7 @@ mod tests {
 
         let child = connection.with_unit_id(42);
 
-        assert_eq!(child.retry(), Some(retry));
+        assert_eq!(child.retry, Some(retry));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make `request` and `response` modules private
- reduce exposed API surface to the intended public entry points
- keep internal module structure available within the crate

## Why
This tightens the public API and makes the crate easier to use and maintain by exposing fewer implementation details.

## Notes
- no functional behavior changes intended