### PR TITLE
feat(tcp): add actor-owned flow control and gateway-busy retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Small Rust Modbus library with typed request/response PDUs and a reusable Modbus
   - write multiple registers
 - Modbus TCP transport with:
   - lazy connect or explicit `connect()`
-  - reusable actor-owned connections with bounded command-channel backpressure
-  - concurrent in-flight requests across cloned handles on one socket
-  - retry of transient I/O failures
-  - per-phase timeouts for connect, write, and read
+  - reusable actor-owned connections with bounded request-channel backpressure
+  - configurable in-flight window for slow gateway-backed buses
+  - retry of transient I/O failures and gateway-busy exception responses
+  - per-phase timeouts for connect, write, queue wait, and on-wire response wait
   - request/response validation for transaction ID, protocol ID, unit ID, and echoed payloads
 - Support for talking to multiple unit IDs through one Modbus TCP connection handle
 - Optional CLI example behind the `cli` feature
@@ -94,9 +94,9 @@ construct the connection with `with_timeouts(...)`.
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
-use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpRetry, ModbusTcpTimeouts};
+use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpTimeouts};
 
-let connection = ModbusTcpConnection::with_timeouts(
+let connection = ModbusTcpConnection::with_config(
     IpAddr::V4(Ipv4Addr::LOCALHOST),
     502,
     1,
@@ -104,8 +104,9 @@ let connection = ModbusTcpConnection::with_timeouts(
     ModbusTcpTimeouts {
         connect_timeout: Duration::from_secs(2),
         write_timeout: Duration::from_secs(2),
-        read_timeout: Duration::from_secs(2),
+        response_timeout: Duration::from_secs(2),
     },
+    ModbusTcpFlowControl::serial_gateway(),
 )
 .with_retry(Some(ModbusTcpRetry {
     initial_delay: Duration::from_millis(100),
@@ -114,16 +115,16 @@ let connection = ModbusTcpConnection::with_timeouts(
 }));
 ```
 
-Read timeout enforcement is actor-owned: each handle attaches an absolute `read_timeout`
-deadline when the request command is submitted. The deadline therefore bounds actor queue wait,
-write time, and response wait time; when it expires, the actor completes the waiter
-with `ReadTimeout` and tears down the socket in the same step. Because a timed-out request may
-leave an unread response on the stream, that teardown is connection-wide: other in-flight requests
-on the same socket can observe a transient connection-aborted read error and retry on a fresh
-connection.
+Flow control is actor-owned: `ModbusTcpFlowControl::max_in_flight` caps requests on the wire,
+and `max_queue_depth` is the bounded backlog that applies backpressure to callers. Use
+`ModbusTcpFlowControl::serial_gateway()` for RTU gateways that drain one serial bus sequentially.
+Queue wait is bounded by `queue_timeout`; the `response_timeout` clock starts only after the actor
+successfully writes the frame to the socket. A single response timeout now fails that transaction,
+quarantines its transaction ID to avoid late-response aliasing, and keeps the TCP socket open.
 
-By default, transient TCP connect/write/read failures are retried with exponential backoff starting
-at 500 ms, multiplied by 1.5, with jitter, and bounded only by `max_elapsed` (2 s). Set
+By default, transient TCP connect/write/read/queue failures and gateway-busy exception responses
+(`0x05`, `0x06`, `0x0A`, `0x0B`) are retried with exponential backoff starting at 500 ms,
+multiplied by 1.5, with jitter, and bounded only by `max_elapsed` (2 s). Set
 `max_times` to cap the number of retries as well. To disable same-call retry, pass
 `with_retry(None)`; the first transient error is returned to the caller for that call, but the
 connection state is still invalidated and the next call reconnects lazily.

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,10 @@ pub enum ModbusError {
     #[error("TCP read timed out")]
     ReadTimeout,
 
+    /// A request waited longer than the configured queue timeout before reaching the wire.
+    #[error("Modbus request queue timed out")]
+    QueueTimeout,
+
     /// A Modbus TCP response frame was structurally invalid.
     #[error("Malformed response: {0}")]
     MalformedResponse(String),
@@ -115,7 +119,47 @@ impl ModbusError {
                 | Self::WriteTimeout
                 | Self::ReadError(_)
                 | Self::ReadTimeout
+                | Self::QueueTimeout
                 | Self::MalformedResponse(_)
         )
+    }
+
+    /// Returns true for Modbus exception codes that indicate temporary gateway/slave busy states.
+    #[must_use]
+    pub fn is_gateway_busy(&self) -> bool {
+        matches!(
+            self,
+            Self::ExceptionResponse { code, .. } if matches!(code, 0x05 | 0x06 | 0x0A | 0x0B)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_busy_exception_codes_are_classified() {
+        for code in [0x05, 0x06, 0x0A, 0x0B] {
+            assert!(
+                ModbusError::ExceptionResponse {
+                    function: 0x83,
+                    code
+                }
+                .is_gateway_busy()
+            );
+        }
+        assert!(
+            !ModbusError::ExceptionResponse {
+                function: 0x83,
+                code: 0x02
+            }
+            .is_gateway_busy()
+        );
+    }
+
+    #[test]
+    fn queue_timeout_is_transient() {
+        assert!(ModbusError::QueueTimeout.is_transient());
     }
 }

--- a/src/tcp/actor.rs
+++ b/src/tcp/actor.rs
@@ -17,166 +17,139 @@ use tracing::{debug, trace, warn};
 
 use crate::tcp::adu::build_modbus_tcp_adu;
 use crate::tcp::codec::{MbapCodec, MbapCodecError};
+use crate::tcp::flow::ModbusTcpFlowControl;
 use crate::tcp::tcp_connection::ModbusTcpConnection;
 use crate::tcp::timeouts::ModbusTcpTimeouts;
 use crate::{ModbusRequest, error::ModbusError};
 
-/// Bounded command capacity used to apply backpressure under burst load.
+/// Default bounded request capacity used to apply backpressure under burst load.
 pub(crate) const COMMAND_CHANNEL_CAPACITY: usize = 128;
+const CONTROL_CHANNEL_CAPACITY: usize = 8;
 /// Maximum number of transaction-id candidates to inspect before reporting exhaustion.
 const MAX_TID_PROBES: usize = u16::MAX as usize + 1;
 
-/// Command sent from connection handles to the owning actor.
+/// Lifecycle command sent from connection handles to the owning actor.
 #[derive(Debug)]
-pub(crate) enum Command {
-    /// Serialize and write a request, then route the response to `reply`.
-    Request {
-        /// Unit identifier to place in the MBAP header.
-        unit_id: u8,
-        /// Typed Modbus request PDU.
-        pdu: ModbusRequest,
-        /// Response channel receiving a raw ADU frame or transport error.
-        reply: oneshot::Sender<Result<Vec<u8>, ModbusError>>,
-        /// Absolute request deadline anchored when the handle submits the command.
-        deadline: Instant,
-    },
+pub(crate) enum ControlCommand {
     /// Eagerly connect and acknowledge the result.
     Connect {
-        /// Acknowledgement channel completed after dialing.
         ack: oneshot::Sender<Result<(), ModbusError>>,
     },
     /// Drop the current socket and fail pending waiters.
-    Disconnect {
-        /// Acknowledgement channel completed after teardown is processed.
-        ack: oneshot::Sender<()>,
-    },
+    Disconnect { ack: oneshot::Sender<()> },
+}
+
+/// Request command sent from connection handles to the owning actor.
+#[derive(Debug)]
+pub(crate) struct RequestCommand {
+    pub(crate) unit_id: u8,
+    pub(crate) pdu: ModbusRequest,
+    pub(crate) reply: oneshot::Sender<Result<Vec<u8>, ModbusError>>,
+    /// Absolute queue deadline anchored when the handle submits the request.
+    pub(crate) queue_deadline: Instant,
+}
+
+/// Small control-channel capacity used by connection handles.
+pub(crate) const fn control_channel_capacity() -> usize {
+    CONTROL_CHANNEL_CAPACITY
 }
 
 /// Pending response waiter and timeout metadata for one transaction id.
 #[derive(Debug)]
 struct PendingEntry {
-    /// Response channel waiting for this transaction's frame or terminal error.
     reply: oneshot::Sender<Result<Vec<u8>, ModbusError>>,
-    /// Absolute request deadline anchored when the handle submits the command.
-    deadline: Instant,
+    /// Absolute response deadline anchored after the frame is written to the socket.
+    response_deadline: Instant,
 }
 
 /// Actor that owns the TCP socket, transaction ids, and pending response map.
 #[derive(Debug)]
 pub(crate) struct Actor {
-    /// Remote Modbus TCP server address.
     address: IpAddr,
-    /// Remote Modbus TCP server port.
     port: u16,
-    /// Connection, read, and write timeout configuration.
     timeouts: ModbusTcpTimeouts,
-    /// Command receiver for handle requests and lifecycle operations.
-    rx: mpsc::Receiver<Command>,
-    /// Watch channel notifying handles whether a socket is currently open.
+    flow: ModbusTcpFlowControl,
+    ctrl_rx: mpsc::Receiver<ControlCommand>,
+    req_rx: mpsc::Receiver<RequestCommand>,
     connected_tx: watch::Sender<bool>,
-    /// Framed socket owned exclusively by the actor when connected.
     framed: Option<Framed<TcpStream, MbapCodec>>,
-    /// Response waiters keyed by Modbus transaction identifier.
     pending: HashMap<u16, PendingEntry>,
-    /// Candidate transaction identifier used by the next request.
+    quarantined: HashMap<u16, Instant>,
     next_tid: u16,
+    ctrl_closed: bool,
+    req_closed: bool,
 }
 
 impl Actor {
-    /// Creates an actor seeded with no open socket.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Remote Modbus TCP server address.
-    /// * `port` - Remote Modbus TCP server port.
-    /// * `timeouts` - Timeout configuration for connect, write, and read operations.
-    /// * `transaction_id` - Initial transaction identifier candidate.
-    /// * `rx` - Command receiver owned by the actor.
-    /// * `connected_tx` - Watch sender used to publish connection state.
-    ///
-    /// # Returns
-    ///
-    /// A disconnected actor ready to run its command loop.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         address: IpAddr,
         port: u16,
         timeouts: ModbusTcpTimeouts,
+        flow: ModbusTcpFlowControl,
         transaction_id: u16,
-        rx: mpsc::Receiver<Command>,
+        ctrl_rx: mpsc::Receiver<ControlCommand>,
+        req_rx: mpsc::Receiver<RequestCommand>,
         connected_tx: watch::Sender<bool>,
     ) -> Self {
         Self {
             address,
             port,
             timeouts,
-            rx,
+            flow,
+            ctrl_rx,
+            req_rx,
             connected_tx,
             framed: None,
             pending: HashMap::new(),
+            quarantined: HashMap::new(),
             next_tid: transaction_id,
+            ctrl_closed: false,
+            req_closed: false,
         }
     }
 
-    /// Runs the actor until all command senders are dropped.
-    ///
-    /// The loop owns the socket, routes responses to pending waiters, handles request deadlines,
-    /// and processes lifecycle commands serially.
+    /// Runs the actor until both command channels are closed and no requests are pending.
     pub(crate) async fn run(mut self) {
         loop {
-            if self.framed.is_none() {
-                match self.rx.recv().await {
-                    None => return,
-                    Some(Command::Disconnect { ack }) => {
-                        self.teardown(None);
+            if self.ctrl_closed && self.req_closed && self.pending.is_empty() {
+                return;
+            }
+
+            if let Some(tid) = self.cancelled_tid() {
+                self.cancel_in_flight(tid);
+                continue;
+            }
+
+            let next_wake = self.earliest_wake();
+            let window_has_room = self.pending.len() < self.flow.max_in_flight && !self.req_closed;
+
+            tokio::select! {
+                ctrl = self.ctrl_rx.recv(), if !self.ctrl_closed => match ctrl {
+                    None => self.ctrl_closed = true,
+                    Some(ControlCommand::Connect { ack }) => {
+                        let result = self.ensure_connected().await;
+                        notify_waiter(ack, result);
+                    }
+                    Some(ControlCommand::Disconnect { ack }) => {
+                        self.teardown(Some(default_teardown_error()));
                         notify_waiter(ack, ());
                     }
-                    Some(Command::Connect { ack }) => {
-                        notify_waiter(ack, self.ensure_connected().await);
-                    }
-                    Some(Command::Request {
-                        unit_id,
-                        pdu,
-                        reply,
-                        deadline,
-                    }) => {
-                        self.connect_then_request(unit_id, pdu, reply, deadline)
-                            .await;
-                    }
-                }
-            } else {
-                let deadline = self.earliest_deadline();
-                tokio::select! {
-                    maybe_cmd = self.rx.recv() => match maybe_cmd {
-                        None => return,
-                        Some(Command::Disconnect { ack }) => {
-                            self.teardown(None);
-                            notify_waiter(ack, ());
-                        }
-                        Some(Command::Connect { ack }) => { notify_waiter(ack, Ok(())); }
-                        Some(Command::Request { unit_id, pdu, reply, deadline }) => self.handle_request(unit_id, pdu, reply, deadline).await,
-                    },
-                    item = Self::next_frame(self.framed.as_mut()) => match item {
-                        Some(Ok(frame)) => self.route_frame(frame),
-                        Some(Err(error)) => self.teardown(Some(read_error_from_stream(error))),
-                        None => self.teardown(Some(ModbusError::ReadError(Arc::new(io::Error::new(io::ErrorKind::UnexpectedEof, "peer closed connection"))))),
-                    },
-                    () = async {
-                        if let Some(deadline) = deadline { sleep_until(deadline).await; }
-                    }, if deadline.is_some() => self.handle_deadline(),
-                }
+                },
+                req = self.req_rx.recv(), if window_has_room => match req {
+                    None => self.req_closed = true,
+                    Some(cmd) => self.dispatch(cmd).await,
+                },
+                item = Self::next_frame(self.framed.as_mut()), if self.framed.is_some() => match item {
+                    Some(Ok(frame)) => self.route_frame(frame),
+                    Some(Err(error)) => self.teardown(Some(read_error_from_stream(error))),
+                    None => self.teardown(Some(ModbusError::ReadError(Arc::new(io::Error::new(io::ErrorKind::UnexpectedEof, "peer closed connection"))))),
+                },
+                () = async { if let Some(deadline) = next_wake { sleep_until(deadline).await; } }, if next_wake.is_some() => self.handle_deadlines(),
             }
         }
     }
 
-    /// Awaits the next decoded ADU frame from an optional framed socket.
-    ///
-    /// # Arguments
-    ///
-    /// * `framed` - Mutable framed socket reference when connected.
-    ///
-    /// # Returns
-    ///
-    /// The next decoded frame result, or `None` when no socket is available or the stream ends.
     async fn next_frame(
         framed: Option<&mut Framed<TcpStream, MbapCodec>>,
     ) -> Option<Result<Vec<u8>, MbapCodecError>> {
@@ -186,14 +159,8 @@ impl Actor {
         }
     }
 
-    /// Opens the TCP connection if the actor is currently disconnected.
-    ///
-    /// # Returns
-    ///
-    /// `Ok(())` when a socket is available, otherwise the connect error or timeout.
     async fn ensure_connected(&mut self) -> Result<(), ModbusError> {
         if self.framed.is_some() {
-            // defensive: connected-state callers short-circuit before reaching this path.
             return Ok(());
         }
         let stream = ModbusTcpConnection::connect_stream(
@@ -209,62 +176,37 @@ impl Actor {
         Ok(())
     }
 
-    /// Ensures a connection exists before dispatching a request.
-    ///
-    /// # Arguments
-    ///
-    /// * `unit_id` - Unit identifier to encode in the MBAP header.
-    /// * `pdu` - Request PDU to serialize and send.
-    /// * `reply` - Response channel completed with a frame or transport error.
-    /// * `deadline` - Absolute request deadline anchored at command submission.
-    async fn connect_then_request(
-        &mut self,
-        unit_id: u8,
-        pdu: ModbusRequest,
-        reply: oneshot::Sender<Result<Vec<u8>, ModbusError>>,
-        deadline: Instant,
-    ) {
-        if deadline <= Instant::now() {
-            notify_waiter(reply, Err(ModbusError::ReadTimeout));
+    async fn dispatch(&mut self, cmd: RequestCommand) {
+        if cmd.queue_deadline <= Instant::now() {
+            notify_waiter(cmd.reply, Err(ModbusError::QueueTimeout));
             return;
         }
-        if let Err(error) = self.ensure_connected().await {
-            notify_waiter(reply, Err(error));
-            return;
+        if self.framed.is_none() {
+            if let Err(error) = self.ensure_connected().await {
+                notify_waiter(cmd.reply, Err(error.clone()));
+                self.fail_backlog(&error);
+                return;
+            }
+            if cmd.queue_deadline <= Instant::now() {
+                notify_waiter(cmd.reply, Err(ModbusError::QueueTimeout));
+                return;
+            }
         }
-        self.handle_request(unit_id, pdu, reply, deadline).await;
+        self.write_on_wire(cmd).await;
     }
 
-    /// Serializes, writes, and tracks a request on the current connection.
-    ///
-    /// # Arguments
-    ///
-    /// * `unit_id` - Unit identifier to encode in the MBAP header.
-    /// * `pdu` - Request PDU to serialize and send.
-    /// * `reply` - Response channel stored until the matching response arrives or times out.
-    /// * `deadline` - Absolute request deadline anchored at command submission.
-    async fn handle_request(
-        &mut self,
-        unit_id: u8,
-        pdu: ModbusRequest,
-        reply: oneshot::Sender<Result<Vec<u8>, ModbusError>>,
-        deadline: Instant,
-    ) {
-        if deadline <= Instant::now() {
-            notify_waiter(reply, Err(ModbusError::ReadTimeout));
-            return;
-        }
+    async fn write_on_wire(&mut self, cmd: RequestCommand) {
         let tid = match self.allocate_tid() {
             Ok(tid) => tid,
             Err(error) => {
-                notify_waiter(reply, Err(error));
+                notify_waiter(cmd.reply, Err(error));
                 return;
             }
         };
-        let adu = match build_modbus_tcp_adu(tid, unit_id, &pdu) {
+        let adu = match build_modbus_tcp_adu(tid, cmd.unit_id, &cmd.pdu) {
             Ok(adu) => adu,
             Err(error) => {
-                notify_waiter(reply, Err(error));
+                notify_waiter(cmd.reply, Err(error));
                 return;
             }
         };
@@ -272,7 +214,7 @@ impl Actor {
         let Some(framed) = self.framed.as_mut() else {
             warn!(tid, "request reached actor without an open connection");
             notify_waiter(
-                reply,
+                cmd.reply,
                 Err(ModbusError::ReadError(Arc::new(io::Error::new(
                     io::ErrorKind::NotConnected,
                     "connection not open",
@@ -282,84 +224,122 @@ impl Actor {
         };
         match timeout(self.timeouts.write_timeout, framed.send(adu)).await {
             Ok(Ok(())) => {
-                self.pending.insert(tid, PendingEntry { reply, deadline });
+                let response_deadline = Instant::now() + self.timeouts.response_timeout;
+                self.pending.insert(
+                    tid,
+                    PendingEntry {
+                        reply: cmd.reply,
+                        response_deadline,
+                    },
+                );
             }
             Ok(Err(error)) => {
-                notify_waiter(reply, Err(write_error_from_sink(error)));
-                self.teardown(None);
+                notify_waiter(cmd.reply, Err(write_error_from_sink(error)));
+                self.teardown(Some(default_teardown_error()));
             }
             Err(_) => {
-                notify_waiter(reply, Err(ModbusError::WriteTimeout));
-                self.teardown(None);
+                notify_waiter(cmd.reply, Err(ModbusError::WriteTimeout));
+                self.teardown(Some(default_teardown_error()));
             }
         }
     }
 
-    /// Allocates an unused transaction identifier for a new request.
+    /// Fails every request currently buffered in the command channel with `error`.
     ///
-    /// # Returns
-    ///
-    /// An available transaction identifier, or `NoFreeTransactionId` when all identifiers are pending.
+    /// A single `try_recv` pass is deliberate. A sender that was parked on a full
+    /// channel at failure time deposits its request once this drain frees capacity, and
+    /// the `run` loop re-dispatches it on the next iteration — where it is either failed
+    /// by a fresh (still-failing) connect attempt or short-circuited by its elapsed
+    /// queue deadline. Looping here until producers quiesce would block the actor from
+    /// servicing control commands and pending-response deadlines, and could not fail
+    /// parked senders deterministically anyway (their wake ordering is runtime-defined).
+    fn fail_backlog(&mut self, error: &ModbusError) {
+        while let Ok(cmd) = self.req_rx.try_recv() {
+            notify_waiter(cmd.reply, Err(error.clone()));
+        }
+    }
+
     fn allocate_tid(&mut self) -> Result<u16, ModbusError> {
+        self.reclaim_quarantine();
         for _ in 0..MAX_TID_PROBES {
             let tid = self.next_tid;
             self.next_tid = self.next_tid.wrapping_add(1);
-            if !self.pending.contains_key(&tid) {
+            if !self.pending.contains_key(&tid) && !self.quarantined.contains_key(&tid) {
                 return Ok(tid);
             }
         }
         Err(ModbusError::NoFreeTransactionId)
     }
 
-    /// Routes a decoded response frame to the matching pending waiter.
-    ///
-    /// # Arguments
-    ///
-    /// * `frame` - Complete Modbus TCP ADU whose first two bytes contain the transaction id.
     fn route_frame(&mut self, frame: Vec<u8>) {
-        // The MBAP codec only yields complete frames with a full header and at least one PDU byte.
         let tid = u16::from_be_bytes([frame[0], frame[1]]);
         if let Some(entry) = self.pending.remove(&tid) {
             notify_waiter(entry.reply, Ok(frame));
+        } else if self.quarantined.remove(&tid).is_some() {
+            debug!(
+                tid,
+                "discarding late response for quarantined transaction id"
+            );
         } else {
             warn!(tid, "ignoring response for unknown transaction id");
         }
     }
 
-    /// Finds the nearest pending response deadline.
-    ///
-    /// # Returns
-    ///
-    /// The earliest deadline among pending requests, or `None` when no requests are pending.
-    fn earliest_deadline(&self) -> Option<Instant> {
-        self.pending.values().map(|entry| entry.deadline).min()
+    fn earliest_wake(&self) -> Option<Instant> {
+        let deadline = self
+            .pending
+            .values()
+            .map(|entry| entry.response_deadline)
+            .chain(self.quarantined.values().copied())
+            .min();
+        let cancellation_poll = (!self.pending.is_empty())
+            .then(|| Instant::now() + std::time::Duration::from_millis(10));
+        deadline.into_iter().chain(cancellation_poll).min()
     }
 
-    /// Completes expired waiters with read timeouts and closes the socket.
-    ///
-    /// Closing the socket is intentionally connection-wide: a timed-out request may still
-    /// leave an unread response on the stream, so remaining waiters receive a transient
-    /// connection-aborted error and can retry on a fresh connection.
-    fn handle_deadline(&mut self) {
+    fn handle_deadlines(&mut self) {
         let now = Instant::now();
+        let cancelled: Vec<u16> = self
+            .pending
+            .iter()
+            .filter_map(|(tid, entry)| entry.reply.is_closed().then_some(*tid))
+            .collect();
+        for tid in cancelled {
+            self.cancel_in_flight(tid);
+        }
         let expired: Vec<u16> = self
             .pending
             .iter()
-            .filter_map(|(tid, entry)| (entry.deadline <= now).then_some(*tid))
+            .filter_map(|(tid, entry)| (entry.response_deadline <= now).then_some(*tid))
             .collect();
         for tid in expired {
             if let Some(entry) = self.pending.remove(&tid) {
                 notify_waiter(entry.reply, Err(ModbusError::ReadTimeout));
+                self.quarantined.insert(tid, now + self.flow.quarantine_ttl);
             }
         }
-        self.teardown(None);
+        self.reclaim_quarantine();
     }
 
-    /// Drops the socket, marks the actor disconnected, and fails pending waiters.
-    ///
-    /// # Arguments
-    ///
-    /// * `reason` - Error to clone for pending waiters, or a default connection-closed error.
+    fn reclaim_quarantine(&mut self) {
+        let now = Instant::now();
+        self.quarantined
+            .retain(|_, reclaim_after| *reclaim_after > now);
+    }
+
+    fn cancelled_tid(&self) -> Option<u16> {
+        self.pending
+            .iter()
+            .find_map(|(tid, entry)| entry.reply.is_closed().then_some(*tid))
+    }
+
+    fn cancel_in_flight(&mut self, tid: u16) {
+        if self.pending.remove(&tid).is_some() {
+            self.quarantined
+                .insert(tid, Instant::now() + self.flow.quarantine_ttl);
+        }
+    }
+
     fn teardown(&mut self, reason: Option<ModbusError>) {
         self.framed = None;
         if self.connected_tx.send(false).is_err() {
@@ -372,11 +352,6 @@ impl Actor {
     }
 }
 
-/// Builds the fallback error used when teardown has no explicit reason.
-///
-/// # Returns
-///
-/// A connection-aborted read error describing the closed connection.
 fn default_teardown_error() -> ModbusError {
     ModbusError::ReadError(Arc::new(io::Error::new(
         io::ErrorKind::ConnectionAborted,
@@ -384,31 +359,12 @@ fn default_teardown_error() -> ModbusError {
     )))
 }
 
-/// Delivers a value to a oneshot waiter, tracing when the receiver has already been dropped.
-///
-/// A dropped receiver is the expected outcome when the originating caller timed out or was
-/// cancelled before the response arrived; there is no error to propagate, so the value is
-/// discarded and the occurrence is traced.
-///
-/// # Arguments
-///
-/// * `reply` - Oneshot sender whose receiver may have been dropped by a cancelled caller.
-/// * `value` - Value to deliver to the waiter.
 fn notify_waiter<T>(reply: oneshot::Sender<T>, value: T) {
     if reply.send(value).is_err() {
         trace!("waiter receiver dropped before delivery; discarding response");
     }
 }
 
-/// Converts a sink failure into a write-side transport error.
-///
-/// # Arguments
-///
-/// * `error` - Error returned while sending through the framed sink.
-///
-/// # Returns
-///
-/// A `WriteError` preserving I/O details when possible.
 fn write_error_from_sink(error: MbapCodecError) -> ModbusError {
     match error {
         MbapCodecError::Io(error) => ModbusError::WriteError(Arc::new(error)),
@@ -419,15 +375,6 @@ fn write_error_from_sink(error: MbapCodecError) -> ModbusError {
     }
 }
 
-/// Converts a stream failure into a read-side transport or protocol error.
-///
-/// # Arguments
-///
-/// * `error` - Error returned while receiving through the framed stream.
-///
-/// # Returns
-///
-/// A read error for socket I/O failures, or the original Modbus protocol error.
 fn read_error_from_stream(error: MbapCodecError) -> ModbusError {
     match error {
         MbapCodecError::Io(error) => ModbusError::ReadError(Arc::new(error)),
@@ -445,14 +392,17 @@ mod tests {
     use super::*;
 
     fn actor_with_seed(seed: u16) -> Actor {
-        let (_tx, rx) = mpsc::channel(1);
+        let (_ctrl_tx, ctrl_rx) = mpsc::channel(1);
+        let (_req_tx, req_rx) = mpsc::channel(1);
         let (connected_tx, _connected_rx) = watch::channel(false);
         Actor::new(
             "127.0.0.1".parse().unwrap(),
             502,
             ModbusTcpTimeouts::default(),
+            ModbusTcpFlowControl::default(),
             seed,
-            rx,
+            ctrl_rx,
+            req_rx,
             connected_tx,
         )
     }
@@ -465,7 +415,7 @@ mod tests {
         (
             PendingEntry {
                 reply,
-                deadline: Instant::now() + Duration::from_secs(1),
+                response_deadline: Instant::now() + Duration::from_secs(1),
             },
             response,
         )
@@ -492,6 +442,197 @@ mod tests {
             actor.allocate_tid(),
             Err(ModbusError::NoFreeTransactionId)
         ));
+    }
+
+    #[test]
+    fn allocate_tid_skips_quarantined_and_reclaims_aged_entries() {
+        let mut actor = actor_with_seed(5);
+        actor
+            .quarantined
+            .insert(5, Instant::now() + Duration::from_secs(1));
+
+        assert_eq!(actor.allocate_tid().unwrap(), 6);
+
+        actor.next_tid = 7;
+        actor
+            .quarantined
+            .insert(7, Instant::now() - Duration::from_millis(1));
+
+        assert_eq!(actor.allocate_tid().unwrap(), 7);
+        assert!(!actor.quarantined.contains_key(&7));
+    }
+
+    #[test]
+    fn route_frame_discards_late_quarantined_response() {
+        let mut actor = actor_with_seed(0);
+        actor
+            .quarantined
+            .insert(42, Instant::now() + Duration::from_secs(1));
+        let frame =
+            crate::tcp::adu::build_modbus_tcp_adu_from_pdu_bytes(42, 1, &[0x03, 0x00]).unwrap();
+
+        actor.route_frame(frame);
+
+        assert!(!actor.quarantined.contains_key(&42));
+        assert!(actor.pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_deadlines_quarantines_timeout_without_tearing_down_socket() {
+        let (client, _server) = loopback_stream_pair().await;
+        let (mut actor, _connected_rx) = connected_actor_with_stream(client);
+        let (expired_reply, expired_response) = oneshot::channel();
+        actor.pending.insert(
+            1,
+            PendingEntry {
+                reply: expired_reply,
+                response_deadline: Instant::now() - Duration::from_millis(1),
+            },
+        );
+        let (sibling, _sibling_response) = pending_entry();
+        actor.pending.insert(2, sibling);
+
+        actor.handle_deadlines();
+
+        assert!(actor.framed.is_some());
+        assert!(actor.pending.contains_key(&2));
+        assert!(!actor.pending.contains_key(&1));
+        assert!(actor.quarantined.contains_key(&1));
+        assert!(matches!(
+            expired_response.await.unwrap(),
+            Err(ModbusError::ReadTimeout)
+        ));
+    }
+
+    #[tokio::test]
+    async fn next_cancelled_tid_frees_slot_and_quarantines_tid() {
+        let mut actor = actor_with_seed(0);
+        actor.flow = ModbusTcpFlowControl::serial_gateway();
+        let (entry, response) = pending_entry();
+        actor.pending.insert(10, entry);
+        drop(response);
+
+        let tid = tokio::time::timeout(
+            Duration::from_secs(1),
+            Actor::next_cancelled_tid(&mut actor.pending),
+        )
+        .await
+        .unwrap();
+        actor.cancel_in_flight(tid);
+
+        assert_eq!(tid, 10);
+        assert!(actor.pending.is_empty());
+        assert!(actor.quarantined.contains_key(&10));
+        assert!(actor.pending.len() < actor.flow.max_in_flight);
+    }
+
+    #[tokio::test]
+    async fn fail_backlog_drains_queued_requests_after_connect_failure() {
+        let (_ctrl_tx, ctrl_rx) = mpsc::channel(1);
+        let (req_tx, req_rx) = mpsc::channel(2);
+        let (connected_tx, _connected_rx) = watch::channel(false);
+        let mut actor = Actor::new(
+            "127.0.0.1".parse().unwrap(),
+            502,
+            ModbusTcpTimeouts::default(),
+            ModbusTcpFlowControl {
+                max_queue_depth: 2,
+                ..ModbusTcpFlowControl::default()
+            },
+            0,
+            ctrl_rx,
+            req_rx,
+            connected_tx,
+        );
+        let (first_reply, first_response) = oneshot::channel();
+        let (second_reply, second_response) = oneshot::channel();
+        let error = ModbusError::ConnectTimeout;
+        req_tx
+            .send(RequestCommand {
+                unit_id: 1,
+                pdu: read_holding_registers(1),
+                reply: first_reply,
+                queue_deadline: Instant::now() + Duration::from_secs(1),
+            })
+            .await
+            .unwrap();
+        req_tx
+            .send(RequestCommand {
+                unit_id: 1,
+                pdu: read_holding_registers(1),
+                reply: second_reply,
+                queue_deadline: Instant::now() + Duration::from_secs(1),
+            })
+            .await
+            .unwrap();
+
+        actor.fail_backlog(&error);
+
+        assert!(matches!(
+            first_response.await.unwrap(),
+            Err(ModbusError::ConnectTimeout)
+        ));
+        assert!(matches!(
+            second_response.await.unwrap(),
+            Err(ModbusError::ConnectTimeout)
+        ));
+    }
+
+    /// A sender parked on a full command channel at connect-failure time is still
+    /// failed: the single-pass drain frees capacity, the parked send completes, and the
+    /// `run` loop re-dispatches it into another (still-failing) connect attempt. This
+    /// exercises the path through `run` rather than `fail_backlog` in isolation, because
+    /// the re-dispatch — not the drain — is what covers the straggler.
+    #[tokio::test]
+    async fn parked_sender_is_failed_via_redispatch_after_connect_failure() {
+        // Reserve a port and drop the listener so connects are refused promptly.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dead_addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let (ctrl_tx, ctrl_rx) = mpsc::channel(1);
+        let (req_tx, req_rx) = mpsc::channel(2);
+        let (connected_tx, _connected_rx) = watch::channel(false);
+        let actor = Actor::new(
+            dead_addr.ip(),
+            dead_addr.port(),
+            ModbusTcpTimeouts {
+                connect_timeout: Duration::from_millis(200),
+                ..ModbusTcpTimeouts::default()
+            },
+            ModbusTcpFlowControl {
+                max_queue_depth: 2,
+                ..ModbusTcpFlowControl::default()
+            },
+            0,
+            ctrl_rx,
+            req_rx,
+            connected_tx,
+        );
+        let run = tokio::spawn(actor.run());
+
+        let mut responses = Vec::new();
+        // Two requests fill the depth-2 channel; the third parks until capacity frees.
+        for _ in 0..3 {
+            let (reply, response) = oneshot::channel();
+            req_tx
+                .send(RequestCommand {
+                    unit_id: 1,
+                    pdu: read_holding_registers(1),
+                    reply,
+                    queue_deadline: Instant::now() + Duration::from_secs(5),
+                })
+                .await
+                .unwrap();
+            responses.push(response);
+        }
+        drop(req_tx);
+        drop(ctrl_tx);
+
+        for response in responses {
+            assert!(response.await.unwrap().is_err());
+        }
+        run.await.unwrap();
     }
 
     #[tokio::test]
@@ -531,39 +672,35 @@ mod tests {
         }
     }
 
-    /// A request whose deadline has already passed must short-circuit with a read
-    /// timeout instead of allocating a transaction id or touching the socket.
-    #[tokio::test]
-    async fn handle_request_with_expired_deadline_replies_read_timeout() {
-        let mut actor = actor_with_seed(0);
-        let (reply, response) = oneshot::channel();
-
-        actor
-            .handle_request(1, read_holding_registers(1), reply, Instant::now())
-            .await;
-
-        assert!(matches!(
-            response.await.unwrap(),
-            Err(ModbusError::ReadTimeout)
-        ));
-        assert!(actor.pending.is_empty());
+    fn request_command(
+        quantity: u16,
+        reply: oneshot::Sender<Result<Vec<u8>, ModbusError>>,
+        queue_deadline: Instant,
+    ) -> RequestCommand {
+        RequestCommand {
+            unit_id: 1,
+            pdu: read_holding_registers(quantity),
+            reply,
+            queue_deadline,
+        }
     }
 
-    /// The lazy-connect path must also honor an already-expired deadline before it
-    /// attempts to dial the server.
+    /// A request whose deadline has already passed must short-circuit with a queue
+    /// timeout instead of allocating a transaction id or touching the socket.
     #[tokio::test]
-    async fn connect_then_request_with_expired_deadline_replies_read_timeout() {
+    async fn dispatch_with_expired_deadline_replies_queue_timeout() {
         let mut actor = actor_with_seed(0);
         let (reply, response) = oneshot::channel();
 
         actor
-            .connect_then_request(1, read_holding_registers(1), reply, Instant::now())
+            .dispatch(request_command(1, reply, Instant::now()))
             .await;
 
         assert!(matches!(
             response.await.unwrap(),
-            Err(ModbusError::ReadTimeout)
+            Err(ModbusError::QueueTimeout)
         ));
+        assert!(actor.pending.is_empty());
         assert!(actor.framed.is_none());
     }
 
@@ -587,15 +724,18 @@ mod tests {
             let (_stream, _) = listener.accept().await.unwrap();
             std::future::pending::<()>().await;
         });
-        let (_tx, rx) = mpsc::channel(1);
+        let (_ctrl_tx, ctrl_rx) = mpsc::channel(1);
+        let (_req_tx, req_rx) = mpsc::channel(1);
         let (connected_tx, connected_rx) = watch::channel(false);
         drop(connected_rx);
         let mut actor = Actor::new(
             addr.ip(),
             addr.port(),
             ModbusTcpTimeouts::default(),
+            ModbusTcpFlowControl::default(),
             0,
-            rx,
+            ctrl_rx,
+            req_rx,
             connected_tx,
         );
 
@@ -607,8 +747,9 @@ mod tests {
     /// When every transaction id is already pending, a new request must be rejected
     /// with `NoFreeTransactionId` rather than overwriting an in-flight waiter.
     #[tokio::test]
-    async fn handle_request_without_free_tid_replies_no_free_transaction_id() {
-        let mut actor = actor_with_seed(0);
+    async fn dispatch_without_free_tid_replies_no_free_transaction_id() {
+        let (client, _server) = loopback_stream_pair().await;
+        let (mut actor, _connected_rx) = connected_actor_with_stream(client);
         for tid in 0..=u16::MAX {
             let (entry, _response) = pending_entry();
             actor.pending.insert(tid, entry);
@@ -616,12 +757,11 @@ mod tests {
         let (reply, response) = oneshot::channel();
 
         actor
-            .handle_request(
+            .dispatch(request_command(
                 1,
-                read_holding_registers(1),
                 reply,
                 Instant::now() + Duration::from_secs(1),
-            )
+            ))
             .await;
 
         assert!(matches!(
@@ -633,17 +773,17 @@ mod tests {
     /// A request that fails PDU validation must surface the validation error to the
     /// caller without consuming the allocated transaction id permanently.
     #[tokio::test]
-    async fn handle_request_with_invalid_pdu_replies_validation_error() {
-        let mut actor = actor_with_seed(0);
+    async fn dispatch_with_invalid_pdu_replies_validation_error() {
+        let (client, _server) = loopback_stream_pair().await;
+        let (mut actor, _connected_rx) = connected_actor_with_stream(client);
         let (reply, response) = oneshot::channel();
 
         actor
-            .handle_request(
-                1,
-                read_holding_registers(0),
+            .dispatch(request_command(
+                0,
                 reply,
                 Instant::now() + Duration::from_secs(1),
-            )
+            ))
             .await;
 
         assert!(matches!(
@@ -653,20 +793,19 @@ mod tests {
         assert!(actor.pending.is_empty());
     }
 
-    /// The defensive guard for a request that reaches `handle_request` without an
+    /// The defensive guard for a request that reaches `write_on_wire` without an
     /// open socket must reply with a `NotConnected` read error.
     #[tokio::test]
-    async fn handle_request_without_socket_replies_not_connected() {
+    async fn write_on_wire_without_socket_replies_not_connected() {
         let mut actor = actor_with_seed(0);
         let (reply, response) = oneshot::channel();
 
         actor
-            .handle_request(
+            .write_on_wire(request_command(
                 1,
-                read_holding_registers(1),
                 reply,
                 Instant::now() + Duration::from_secs(1),
-            )
+            ))
             .await;
 
         assert!(matches!(
@@ -705,7 +844,8 @@ mod tests {
     }
 
     fn connected_actor_with_stream(stream: TcpStream) -> (Actor, watch::Receiver<bool>) {
-        let (_tx, rx) = mpsc::channel(1);
+        let (_ctrl_tx, ctrl_rx) = mpsc::channel(1);
+        let (_req_tx, req_rx) = mpsc::channel(1);
         let (connected_tx, connected_rx) = watch::channel(true);
         let mut actor = Actor::new(
             "127.0.0.1".parse().unwrap(),
@@ -713,10 +853,12 @@ mod tests {
             ModbusTcpTimeouts {
                 connect_timeout: Duration::from_secs(1),
                 write_timeout: Duration::from_millis(10),
-                read_timeout: Duration::from_secs(1),
+                response_timeout: Duration::from_secs(1),
             },
+            ModbusTcpFlowControl::default(),
             0,
-            rx,
+            ctrl_rx,
+            req_rx,
             connected_tx,
         );
         actor.framed = Some(Framed::new(stream, MbapCodec));
@@ -759,12 +901,11 @@ mod tests {
         let (reply, response) = oneshot::channel();
 
         actor
-            .connect_then_request(
+            .dispatch(request_command(
                 1,
-                read_holding_registers(1),
                 reply,
                 Instant::now() + Duration::from_secs(1),
-            )
+            ))
             .await;
         let frame = Actor::next_frame(actor.framed.as_mut())
             .await
@@ -781,7 +922,7 @@ mod tests {
     /// This relies on the local OS honoring `SO_LINGER(0)` as an immediate reset for a
     /// loopback socket pair before the client write below.
     #[tokio::test]
-    async fn handle_request_write_error_replies_and_tears_down() {
+    async fn dispatch_write_error_replies_and_tears_down() {
         let (client, server) = loopback_stream_pair().await;
         let server = server.into_std().unwrap();
         socket2::SockRef::from(&server)
@@ -795,12 +936,11 @@ mod tests {
         let (reply, response) = oneshot::channel();
 
         actor
-            .handle_request(
+            .dispatch(request_command(
                 1,
-                read_holding_registers(1),
                 reply,
                 Instant::now() + Duration::from_secs(1),
-            )
+            ))
             .await;
 
         assert!(matches!(
@@ -823,7 +963,7 @@ mod tests {
     /// This assumes the local OS eventually reports `WouldBlock` after the test fills a
     /// loopback socket send buffer while the peer remains open and unread.
     #[tokio::test]
-    async fn handle_request_write_timeout_replies_and_tears_down() {
+    async fn dispatch_write_timeout_replies_and_tears_down() {
         let (client, _server) = loopback_stream_pair().await;
         let filler = vec![0xA5; 64 * 1024];
         loop {
@@ -840,12 +980,11 @@ mod tests {
         let (reply, response) = oneshot::channel();
 
         actor
-            .handle_request(
+            .dispatch(request_command(
                 1,
-                read_holding_registers(1),
                 reply,
                 Instant::now() + Duration::from_secs(1),
-            )
+            ))
             .await;
 
         assert!(matches!(

--- a/src/tcp/actor.rs
+++ b/src/tcp/actor.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{SinkExt, StreamExt, future::poll_fn};
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::{Instant, sleep_until, timeout};
@@ -116,11 +116,6 @@ impl Actor {
                 return;
             }
 
-            if let Some(tid) = self.cancelled_tid() {
-                self.cancel_in_flight(tid);
-                continue;
-            }
-
             let next_wake = self.earliest_wake();
             let window_has_room = self.pending.len() < self.flow.max_in_flight && !self.req_closed;
 
@@ -145,6 +140,7 @@ impl Actor {
                     Some(Err(error)) => self.teardown(Some(read_error_from_stream(error))),
                     None => self.teardown(Some(ModbusError::ReadError(Arc::new(io::Error::new(io::ErrorKind::UnexpectedEof, "peer closed connection"))))),
                 },
+                tid = Self::next_cancelled_tid(&mut self.pending), if !self.pending.is_empty() => self.cancel_in_flight(tid),
                 () = async { if let Some(deadline) = next_wake { sleep_until(deadline).await; } }, if next_wake.is_some() => self.handle_deadlines(),
             }
         }
@@ -157,6 +153,16 @@ impl Actor {
             Some(framed) => framed.next().await,
             None => None,
         }
+    }
+
+    async fn next_cancelled_tid(pending: &mut HashMap<u16, PendingEntry>) -> u16 {
+        poll_fn(|cx| {
+            pending
+                .iter_mut()
+                .find_map(|(tid, entry)| entry.reply.poll_closed(cx).is_ready().then_some(*tid))
+                .map_or(std::task::Poll::Pending, std::task::Poll::Ready)
+        })
+        .await
     }
 
     async fn ensure_connected(&mut self) -> Result<(), ModbusError> {
@@ -286,27 +292,15 @@ impl Actor {
     }
 
     fn earliest_wake(&self) -> Option<Instant> {
-        let deadline = self
-            .pending
+        self.pending
             .values()
             .map(|entry| entry.response_deadline)
             .chain(self.quarantined.values().copied())
-            .min();
-        let cancellation_poll = (!self.pending.is_empty())
-            .then(|| Instant::now() + std::time::Duration::from_millis(10));
-        deadline.into_iter().chain(cancellation_poll).min()
+            .min()
     }
 
     fn handle_deadlines(&mut self) {
         let now = Instant::now();
-        let cancelled: Vec<u16> = self
-            .pending
-            .iter()
-            .filter_map(|(tid, entry)| entry.reply.is_closed().then_some(*tid))
-            .collect();
-        for tid in cancelled {
-            self.cancel_in_flight(tid);
-        }
         let expired: Vec<u16> = self
             .pending
             .iter()
@@ -325,12 +319,6 @@ impl Actor {
         let now = Instant::now();
         self.quarantined
             .retain(|_, reclaim_after| *reclaim_after > now);
-    }
-
-    fn cancelled_tid(&self) -> Option<u16> {
-        self.pending
-            .iter()
-            .find_map(|(tid, entry)| entry.reply.is_closed().then_some(*tid))
     }
 
     fn cancel_in_flight(&mut self, tid: u16) {

--- a/src/tcp/flow.rs
+++ b/src/tcp/flow.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 tinymb contributors
+
+//! Application-layer flow control for Modbus TCP actors.
+
+use std::time::Duration;
+
+use crate::error::ModbusError;
+use crate::tcp::actor::COMMAND_CHANNEL_CAPACITY;
+
+/// Application-layer flow control for one Modbus TCP transport actor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ModbusTcpFlowControl {
+    /// Maximum number of transactions on the wire at once. Must be >= 1.
+    pub max_in_flight: usize,
+    /// Maximum number of admitted-but-not-yet-on-wire requests buffered in the actor.
+    pub max_queue_depth: usize,
+    /// Maximum time a request may wait between submission and reaching the wire.
+    pub queue_timeout: Duration,
+    /// Time a timed-out/cancelled transaction id remains reserved.
+    pub quarantine_ttl: Duration,
+}
+
+impl ModbusTcpFlowControl {
+    /// Preset for serial-backed gateways where the downstream bus is sequential.
+    #[must_use]
+    pub fn serial_gateway() -> Self {
+        Self {
+            max_in_flight: 1,
+            ..Self::default()
+        }
+    }
+
+    /// Validates flow-control invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModbusError::ValidationError`] if any numeric bound is zero.
+    pub fn validate(&self) -> Result<(), ModbusError> {
+        if self.max_in_flight == 0 {
+            return Err(ModbusError::ValidationError(
+                "flow_control max_in_flight must be >= 1".to_string(),
+            ));
+        }
+        if self.max_queue_depth == 0 {
+            return Err(ModbusError::ValidationError(
+                "flow_control max_queue_depth must be >= 1".to_string(),
+            ));
+        }
+        if self.queue_timeout.is_zero() {
+            return Err(ModbusError::ValidationError(
+                "flow_control queue_timeout must be > 0".to_string(),
+            ));
+        }
+        if self.quarantine_ttl.is_zero() {
+            return Err(ModbusError::ValidationError(
+                "flow_control quarantine_ttl must be > 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for ModbusTcpFlowControl {
+    fn default() -> Self {
+        Self {
+            max_in_flight: 16,
+            max_queue_depth: COMMAND_CHANNEL_CAPACITY,
+            queue_timeout: Duration::from_secs(5),
+            quarantine_ttl: Duration::from_secs(10),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_and_serial_gateway_are_documented() {
+        assert_eq!(ModbusTcpFlowControl::default().max_in_flight, 16);
+        assert_eq!(ModbusTcpFlowControl::serial_gateway().max_in_flight, 1);
+    }
+
+    #[test]
+    fn validate_rejects_invalid_values() {
+        assert!(
+            ModbusTcpFlowControl {
+                max_in_flight: 0,
+                ..Default::default()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            ModbusTcpFlowControl {
+                max_queue_depth: 0,
+                ..Default::default()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            ModbusTcpFlowControl {
+                queue_timeout: Duration::ZERO,
+                ..Default::default()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            ModbusTcpFlowControl {
+                quarantine_ttl: Duration::ZERO,
+                ..Default::default()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(ModbusTcpFlowControl::default().validate().is_ok());
+    }
+}

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -11,11 +11,13 @@
 mod actor;
 mod adu;
 mod codec;
+mod flow;
 mod frame;
 mod retry;
 mod timeouts;
 
 mod tcp_connection;
+pub use flow::ModbusTcpFlowControl;
 pub use retry::ModbusTcpRetry;
 pub use tcp_connection::ModbusTcpConnection;
 pub use timeouts::ModbusTcpTimeouts;

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -24,10 +24,11 @@ use crate::error::ModbusError;
 ///
 /// # Retried errors
 ///
-/// Only errors classified as transient by [`ModbusError::is_transient`] are
-/// retried. Invalid retry configuration, request validation failures, protocol
-/// mismatches, Modbus exception responses, and request/response mismatches are
-/// returned immediately.
+/// Errors classified as transient by [`ModbusError::is_transient`] are retried.
+/// Gateway/slave-busy Modbus exception responses are also retried when
+/// [`Self::retry_gateway_busy`] is enabled. Invalid retry configuration, request
+/// validation failures, protocol mismatches, non-busy Modbus exception responses,
+/// and request/response mismatches are returned immediately.
 ///
 /// # Validation
 ///
@@ -60,6 +61,8 @@ pub struct ModbusTcpRetry {
     pub max_times: Option<usize>,
     /// Whether to add jitter to retry sleeps.
     pub jitter: bool,
+    /// Whether Modbus gateway/slave busy exception responses should be retried.
+    pub retry_gateway_busy: bool,
 }
 
 impl ModbusTcpRetry {
@@ -149,7 +152,9 @@ where
 {
     operation
         .retry(retry.to_backoff()?)
-        .when(ModbusError::is_transient)
+        .when(move |error: &ModbusError| {
+            error.is_transient() || (retry.retry_gateway_busy && error.is_gateway_busy())
+        })
         .await
 }
 
@@ -162,6 +167,7 @@ impl Default for ModbusTcpRetry {
             max_elapsed: Duration::from_secs(2),
             max_times: None,
             jitter: true,
+            retry_gateway_busy: true,
         }
     }
 }
@@ -190,6 +196,7 @@ mod tests {
         assert_eq!(retry.max_elapsed, Duration::from_secs(2));
         assert_eq!(retry.max_times, None);
         assert!(retry.jitter);
+        assert!(retry.retry_gateway_busy);
     }
 
     #[test]

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -11,10 +11,11 @@ use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
-use tokio::time::{Instant, timeout, timeout_at};
+use tokio::time::timeout;
 use tracing::debug;
 
-use crate::tcp::actor::{Actor, COMMAND_CHANNEL_CAPACITY, Command};
+use crate::tcp::actor::{Actor, ControlCommand, RequestCommand, control_channel_capacity};
+use crate::tcp::flow::ModbusTcpFlowControl;
 use crate::tcp::frame::MBAP_HEADER_LEN;
 use crate::tcp::retry::{ModbusTcpRetry, retry_transient};
 use crate::tcp::timeouts::ModbusTcpTimeouts;
@@ -25,16 +26,16 @@ use crate::{ModbusRequest, ModbusResponse, error::ModbusError};
 /// Clones are lightweight command senders to a single background actor that owns
 /// the TCP socket, pending response map, and transaction-id counter. The actor
 /// connects lazily on the first warm-up or request, reconnects after transport
-/// teardown, and applies bounded channel backpressure under burst load. The
-/// caller-facing read timeout deadline starts before the request enters the
-/// actor, so it bounds queue wait, write, and response wait time together while
-/// the actor remains the single owner of timeout enforcement and socket teardown.
+/// teardown, applies bounded in-flight flow control, and uses a bounded request
+/// channel as backpressure. Queue wait is bounded by flow-control settings;
+/// response timeout starts when the actor writes the request on the socket.
 #[derive(Clone, Debug)]
 pub struct ModbusTcpConnection {
-    tx: mpsc::Sender<Command>,
+    req_tx: mpsc::Sender<RequestCommand>,
+    ctrl_tx: mpsc::Sender<ControlCommand>,
     unit_id: u8,
     connected: watch::Receiver<bool>,
-    read_timeout: Duration,
+    queue_timeout: Duration,
     retry: Option<ModbusTcpRetry>,
 }
 
@@ -60,9 +61,81 @@ impl ModbusTcpConnection {
         transaction_id: u16,
         timeouts: ModbusTcpTimeouts,
     ) -> Self {
-        Self::spawn_with_timeouts(address, port, unit_id, transaction_id, timeouts).0
+        Self::with_config(
+            address,
+            port,
+            unit_id,
+            transaction_id,
+            timeouts,
+            ModbusTcpFlowControl::default(),
+        )
     }
 
+    /// Creates a connection handle with explicit timeout and flow-control settings.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `flow_control` violates [`ModbusTcpFlowControl::validate`].
+    #[must_use]
+    #[allow(clippy::expect_used)]
+    pub fn with_config(
+        address: IpAddr,
+        port: u16,
+        unit_id: u8,
+        transaction_id: u16,
+        timeouts: ModbusTcpTimeouts,
+        flow_control: ModbusTcpFlowControl,
+    ) -> Self {
+        flow_control
+            .validate()
+            .expect("invalid Modbus TCP flow-control configuration");
+        Self::spawn_with_config(
+            address,
+            port,
+            unit_id,
+            transaction_id,
+            timeouts,
+            flow_control,
+        )
+        .0
+    }
+
+    fn spawn_with_config(
+        address: IpAddr,
+        port: u16,
+        unit_id: u8,
+        transaction_id: u16,
+        timeouts: ModbusTcpTimeouts,
+        flow_control: ModbusTcpFlowControl,
+    ) -> (Self, JoinHandle<()>) {
+        let (req_tx, req_rx) = mpsc::channel(flow_control.max_queue_depth);
+        let (ctrl_tx, ctrl_rx) = mpsc::channel(control_channel_capacity());
+        let (connected_tx, connected) = watch::channel(false);
+        let actor = Actor::new(
+            address,
+            port,
+            timeouts,
+            flow_control,
+            transaction_id,
+            ctrl_rx,
+            req_rx,
+            connected_tx,
+        );
+        let actor_task = tokio::spawn(actor.run());
+        (
+            Self {
+                req_tx,
+                ctrl_tx,
+                unit_id,
+                connected,
+                queue_timeout: flow_control.queue_timeout,
+                retry: Some(ModbusTcpRetry::default()),
+            },
+            actor_task,
+        )
+    }
+
+    #[cfg(test)]
     fn spawn_with_timeouts(
         address: IpAddr,
         port: u16,
@@ -70,19 +143,13 @@ impl ModbusTcpConnection {
         transaction_id: u16,
         timeouts: ModbusTcpTimeouts,
     ) -> (Self, JoinHandle<()>) {
-        let (tx, rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
-        let (connected_tx, connected) = watch::channel(false);
-        let actor = Actor::new(address, port, timeouts, transaction_id, rx, connected_tx);
-        let actor_task = tokio::spawn(actor.run());
-        (
-            Self {
-                tx,
-                unit_id,
-                connected,
-                read_timeout: timeouts.read_timeout,
-                retry: Some(ModbusTcpRetry::default()),
-            },
-            actor_task,
+        Self::spawn_with_config(
+            address,
+            port,
+            unit_id,
+            transaction_id,
+            timeouts,
+            ModbusTcpFlowControl::default(),
         )
     }
 
@@ -97,10 +164,11 @@ impl ModbusTcpConnection {
     #[must_use]
     pub fn with_unit_id(&self, unit_id: u8) -> Self {
         Self {
-            tx: self.tx.clone(),
+            req_tx: self.req_tx.clone(),
+            ctrl_tx: self.ctrl_tx.clone(),
             unit_id,
             connected: self.connected.clone(),
-            read_timeout: self.read_timeout,
+            queue_timeout: self.queue_timeout,
             retry: self.retry,
         }
     }
@@ -126,8 +194,8 @@ impl ModbusTcpConnection {
     /// Returns connect or transport errors reported by the actor.
     pub async fn connect(&self) -> Result<(), ModbusError> {
         let (ack, reply) = oneshot::channel();
-        self.tx
-            .send(Command::Connect { ack })
+        self.ctrl_tx
+            .send(ControlCommand::Connect { ack })
             .await
             .map_err(|_| actor_terminated_error())?;
         reply.await.map_err(|_| actor_terminated_error())?
@@ -140,7 +208,7 @@ impl ModbusTcpConnection {
     /// another handle reconnects afterward.
     pub async fn disconnect(&self) {
         let (ack, processed) = oneshot::channel();
-        if let Err(error) = self.tx.send(Command::Disconnect { ack }).await {
+        if let Err(error) = self.ctrl_tx.send(ControlCommand::Disconnect { ack }).await {
             debug!(%error, "connection actor already stopped during disconnect");
             return;
         }
@@ -160,20 +228,17 @@ impl ModbusTcpConnection {
         unit_id: u8,
         pdu: &ModbusRequest,
     ) -> Result<ModbusResponse, ModbusError> {
-        let deadline = Instant::now() + self.read_timeout;
         let (reply, response) = oneshot::channel();
-        let command = Command::Request {
+        let command = RequestCommand {
             unit_id,
             pdu: pdu.clone(),
             reply,
-            deadline,
+            queue_deadline: tokio::time::Instant::now() + self.queue_timeout,
         };
-        match timeout_at(deadline, self.tx.send(command)).await {
-            Ok(Ok(())) => {}
-            // defensive: actor death races are non-deterministic in normal operation.
-            Ok(Err(_)) => return Err(actor_terminated_error()),
-            Err(_) => return Err(ModbusError::ReadTimeout),
-        }
+        self.req_tx
+            .send(command)
+            .await
+            .map_err(|_| actor_terminated_error())?;
 
         let response_buffer = match response.await {
             Ok(Ok(frame)) => frame,
@@ -343,42 +408,58 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_once_bounds_wait_for_full_command_channel() {
-        let (tx, _rx) = mpsc::channel(1);
-        let (connected_tx, connected) = watch::channel(false);
-        let (ack, _processed) = oneshot::channel();
-        tx.try_send(Command::Disconnect { ack }).unwrap();
-        drop(connected_tx);
+    async fn send_once_backpressures_on_full_request_channel() {
+        let (req_tx, _req_rx) = mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
+        let (_connected_tx, connected) = watch::channel(false);
+        let (reply, _response) = oneshot::channel();
+        req_tx
+            .try_send(RequestCommand {
+                unit_id: 1,
+                pdu: ModbusRequest::ReadHoldingRegisters {
+                    starting_address: 0,
+                    quantity: 1,
+                },
+                reply,
+                queue_deadline: tokio::time::Instant::now() + Duration::from_secs(1),
+            })
+            .unwrap();
         let connection = ModbusTcpConnection {
-            tx,
+            req_tx,
+            ctrl_tx,
             unit_id: 1,
             connected,
-            read_timeout: Duration::from_millis(10),
+            queue_timeout: Duration::from_millis(10),
             retry: None,
         };
 
-        let result = connection
-            .send_once(
+        let result = timeout(
+            Duration::from_millis(10),
+            connection.send_once(
                 1,
                 &ModbusRequest::ReadHoldingRegisters {
                     starting_address: 0,
                     quantity: 1,
                 },
-            )
-            .await;
+            ),
+        )
+        .await;
 
-        assert!(matches!(result, Err(ModbusError::ReadTimeout)));
+        assert!(result.is_err());
     }
 
     fn handle_with_dead_actor() -> ModbusTcpConnection {
-        let (tx, rx) = mpsc::channel(1);
+        let (req_tx, req_rx) = mpsc::channel(1);
+        let (ctrl_tx, ctrl_rx) = mpsc::channel(1);
         let (_connected_tx, connected) = watch::channel(false);
-        drop(rx);
+        drop(req_rx);
+        drop(ctrl_rx);
         ModbusTcpConnection {
-            tx,
+            req_tx,
+            ctrl_tx,
             unit_id: 1,
             connected,
-            read_timeout: Duration::from_millis(50),
+            queue_timeout: Duration::from_millis(50),
             retry: None,
         }
     }
@@ -420,17 +501,19 @@ mod tests {
     /// public disconnect call must return after logging the terminated actor.
     #[tokio::test]
     async fn disconnect_returns_when_actor_drops_ack() {
-        let (tx, mut rx) = mpsc::channel(1);
+        let (req_tx, _req_rx) = mpsc::channel(1);
+        let (ctrl_tx, mut ctrl_rx) = mpsc::channel(1);
         let (_connected_tx, connected) = watch::channel(false);
         let connection = ModbusTcpConnection {
-            tx,
+            req_tx,
+            ctrl_tx,
             unit_id: 1,
             connected,
-            read_timeout: Duration::from_millis(50),
+            queue_timeout: Duration::from_millis(50),
             retry: None,
         };
         tokio::spawn(async move {
-            if let Some(Command::Disconnect { ack }) = rx.recv().await {
+            if let Some(ControlCommand::Disconnect { ack }) = ctrl_rx.recv().await {
                 drop(ack);
             }
         });
@@ -442,17 +525,19 @@ mod tests {
     /// a terminated-actor transport error.
     #[tokio::test]
     async fn send_once_reports_dropped_response_waiter() {
-        let (tx, mut rx) = mpsc::channel(1);
+        let (req_tx, mut req_rx) = mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
         let (_connected_tx, connected) = watch::channel(false);
         let connection = ModbusTcpConnection {
-            tx,
+            req_tx,
+            ctrl_tx,
             unit_id: 1,
             connected,
-            read_timeout: Duration::from_millis(50),
+            queue_timeout: Duration::from_millis(50),
             retry: None,
         };
         tokio::spawn(async move {
-            if let Some(Command::Request { reply, .. }) = rx.recv().await {
+            if let Some(RequestCommand { reply, .. }) = req_rx.recv().await {
                 drop(reply);
             }
         });
@@ -481,7 +566,7 @@ mod tests {
         let timeouts = ModbusTcpTimeouts {
             connect_timeout: Duration::from_millis(50),
             write_timeout: Duration::from_millis(50),
-            read_timeout: Duration::from_millis(50),
+            response_timeout: Duration::from_millis(50),
         };
         let connection = ModbusTcpConnection::with_timeouts(addr.ip(), addr.port(), 1, 0, timeouts)
             .with_retry(None);

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -76,6 +76,9 @@ impl ModbusTcpConnection {
     /// # Panics
     ///
     /// Panics if `flow_control` violates [`ModbusTcpFlowControl::validate`].
+    /// Flow control is validated synchronously because its queue depth is needed
+    /// before the actor task and request channel are spawned; retry policies are
+    /// validated later when a request starts.
     #[must_use]
     #[allow(clippy::expect_used)]
     pub fn with_config(

--- a/src/tcp/timeouts.rs
+++ b/src/tcp/timeouts.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const DEFAULT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
-pub(crate) const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Per-operation time limits used by [`crate::tcp::ModbusTcpConnection`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -16,8 +16,8 @@ pub struct ModbusTcpTimeouts {
     pub connect_timeout: Duration,
     /// Maximum time allowed to write one Modbus TCP frame.
     pub write_timeout: Duration,
-    /// Maximum time allowed to read one Modbus TCP response.
-    pub read_timeout: Duration,
+    /// Maximum time allowed to receive one Modbus TCP response after its frame is written.
+    pub response_timeout: Duration,
 }
 
 impl Default for ModbusTcpTimeouts {
@@ -25,7 +25,7 @@ impl Default for ModbusTcpTimeouts {
         Self {
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             write_timeout: DEFAULT_WRITE_TIMEOUT,
-            read_timeout: DEFAULT_READ_TIMEOUT,
+            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
         }
     }
 }
@@ -41,6 +41,6 @@ mod tests {
 
         assert_eq!(timeouts.connect_timeout, Duration::from_secs(5));
         assert_eq!(timeouts.write_timeout, Duration::from_secs(5));
-        assert_eq!(timeouts.read_timeout, Duration::from_secs(5));
+        assert_eq!(timeouts.response_timeout, Duration::from_secs(5));
     }
 }

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -812,6 +812,70 @@ async fn one_timed_out_tid_is_quarantined_while_sibling_and_socket_survive() {
 }
 
 #[tokio::test]
+async fn gateway_busy_exception_retries_when_enabled() {
+    let addr = spawn_mock_server(|mut stream| async move {
+        let first = read_request_frame(&mut stream).await.unwrap();
+        let busy =
+            build_exception_response_frame(first.transaction_id, first.unit_id, first.pdu[0], 0x0B);
+        stream.write_all(&busy).await.unwrap();
+
+        let second = read_request_frame(&mut stream).await.unwrap();
+        let response = make_read_coils_response(second.transaction_id, second.unit_id, &[true]);
+        stream.write_all(&response).await.unwrap();
+    })
+    .await;
+
+    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+        .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let response = conn.send_message(&request).await.unwrap();
+
+    assert_eq!(response, ModbusResponse::ReadCoils { coils: vec![true] });
+}
+
+#[tokio::test]
+async fn gateway_busy_exception_does_not_retry_when_disabled() {
+    let requests = Arc::new(AtomicU8::new(0));
+    let addr = spawn_mock_server({
+        let requests = Arc::clone(&requests);
+        move |mut stream| async move {
+            let request = read_request_frame(&mut stream).await.unwrap();
+            requests.fetch_add(1, Ordering::SeqCst);
+            let busy = build_exception_response_frame(
+                request.transaction_id,
+                request.unit_id,
+                request.pdu[0],
+                0x0B,
+            );
+            stream.write_all(&busy).await.unwrap();
+        }
+    })
+    .await;
+
+    let conn =
+        ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0).with_retry(Some(ModbusTcpRetry {
+            retry_gateway_busy: false,
+            ..fast_retry(Duration::from_millis(500), None)
+        }));
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let error = conn.send_message(&request).await.unwrap_err();
+
+    assert!(matches!(
+        error,
+        ModbusError::ExceptionResponse { code: 0x0B, .. }
+    ));
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn send_message_with_disabled_retry_does_not_retry() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -21,7 +21,7 @@ use tokio::sync::Mutex;
 mod support;
 
 use tiny_mb::ModbusError;
-use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpRetry, ModbusTcpTimeouts};
+use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpTimeouts};
 use tiny_mb::{ModbusRequest, ModbusResponse};
 
 use support::{
@@ -644,7 +644,7 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
         }
     });
 
-    let conn = ModbusTcpConnection::with_timeouts(
+    let conn = ModbusTcpConnection::with_config(
         addr.ip(),
         addr.port(),
         1,
@@ -654,6 +654,7 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
             write_timeout: Duration::from_secs(1),
             response_timeout: Duration::from_secs(1),
         },
+        ModbusTcpFlowControl::serial_gateway(),
     );
 
     let request = ModbusRequest::ReadCoils {
@@ -673,6 +674,137 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
     let response = conn.send_message(&request).await.unwrap();
     assert_eq!(
         response,
+        ModbusResponse::ReadCoils {
+            coils: vec![true, false]
+        }
+    );
+}
+
+#[tokio::test]
+async fn serial_gateway_never_exceeds_one_in_flight_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let first = read_request_frame(&mut stream).await.unwrap();
+
+        let second_before_first_response =
+            tokio::time::timeout(Duration::from_millis(50), read_request_frame(&mut stream)).await;
+        assert!(second_before_first_response.is_err());
+
+        let first_response = make_read_coils_response(first.transaction_id, first.unit_id, &[true]);
+        stream.write_all(&first_response).await.unwrap();
+
+        let second = read_request_frame(&mut stream).await.unwrap();
+        let second_response =
+            make_read_coils_response(second.transaction_id, second.unit_id, &[false]);
+        stream.write_all(&second_response).await.unwrap();
+    });
+
+    let conn = ModbusTcpConnection::with_config(
+        addr.ip(),
+        addr.port(),
+        1,
+        0,
+        ModbusTcpTimeouts {
+            connect_timeout: Duration::from_secs(1),
+            write_timeout: Duration::from_secs(1),
+            response_timeout: Duration::from_secs(1),
+        },
+        ModbusTcpFlowControl::serial_gateway(),
+    );
+    let request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+
+    let first_conn = conn.clone();
+    let first_request = request.clone();
+    let first = tokio::spawn(async move { first_conn.send_message(&first_request).await });
+    let second = conn.send_message(&request);
+    let (first, second) = tokio::join!(first, second);
+
+    assert!(first.unwrap().is_ok());
+    assert!(second.is_ok());
+}
+
+#[tokio::test]
+async fn one_timed_out_tid_is_quarantined_while_sibling_and_socket_survive() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (slow_started_tx, slow_started_rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let slow = read_request_frame(&mut stream).await.unwrap();
+        let _ = slow_started_tx.send(());
+        let sibling = read_request_frame(&mut stream).await.unwrap();
+
+        let sibling_response =
+            make_read_coils_response(sibling.transaction_id, sibling.unit_id, &[false, true]);
+        stream.write_all(&sibling_response).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(45)).await;
+        let late_slow_response =
+            make_read_coils_response(slow.transaction_id, slow.unit_id, &[true]);
+        stream.write_all(&late_slow_response).await.unwrap();
+
+        let follow_up = read_request_frame(&mut stream).await.unwrap();
+        let follow_up_response =
+            make_read_coils_response(follow_up.transaction_id, follow_up.unit_id, &[true, false]);
+        stream.write_all(&follow_up_response).await.unwrap();
+    });
+
+    let conn = ModbusTcpConnection::with_config(
+        addr.ip(),
+        addr.port(),
+        1,
+        0,
+        ModbusTcpTimeouts {
+            connect_timeout: Duration::from_secs(1),
+            write_timeout: Duration::from_secs(1),
+            response_timeout: Duration::from_millis(30),
+        },
+        ModbusTcpFlowControl {
+            max_in_flight: 2,
+            quarantine_ttl: Duration::from_secs(1),
+            ..ModbusTcpFlowControl::default()
+        },
+    )
+    .with_retry(None);
+    let slow_request = ModbusRequest::ReadCoils {
+        starting_address: 0,
+        quantity: 1,
+    };
+    let sibling_request = ModbusRequest::ReadCoils {
+        starting_address: 10,
+        quantity: 2,
+    };
+
+    let slow_conn = conn.clone();
+    let slow = tokio::spawn(async move { slow_conn.send_message(&slow_request).await });
+    slow_started_rx.await.unwrap();
+    let sibling = conn.send_message(&sibling_request);
+    let (slow, sibling) = tokio::join!(slow, sibling);
+
+    assert!(matches!(slow.unwrap(), Err(ModbusError::ReadTimeout)));
+    assert_eq!(
+        sibling.unwrap(),
+        ModbusResponse::ReadCoils {
+            coils: vec![false, true]
+        }
+    );
+
+    let follow_up = conn
+        .send_message(&ModbusRequest::ReadCoils {
+            starting_address: 20,
+            quantity: 2,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        follow_up,
         ModbusResponse::ReadCoils {
             coils: vec![true, false]
         }

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -60,6 +60,7 @@ fn fast_retry(max_elapsed: Duration, max_times: Option<usize>) -> ModbusTcpRetry
         max_elapsed,
         max_times,
         jitter: false,
+        retry_gateway_busy: true,
     }
 }
 
@@ -524,7 +525,7 @@ async fn send_message_returns_read_timeout_from_slow_server() {
         ModbusTcpTimeouts {
             connect_timeout: Duration::from_millis(50),
             write_timeout: Duration::from_millis(50),
-            read_timeout: Duration::from_millis(25),
+            response_timeout: Duration::from_millis(25),
         },
     )
     .with_retry(None);
@@ -600,7 +601,7 @@ async fn reader_death_drains_pending_and_next_call_reconnects() {
         ModbusTcpTimeouts {
             connect_timeout: Duration::from_millis(100),
             write_timeout: Duration::from_millis(100),
-            read_timeout: Duration::from_millis(25),
+            response_timeout: Duration::from_millis(25),
         },
     );
     let request = ModbusRequest::ReadCoils {
@@ -651,7 +652,7 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
         ModbusTcpTimeouts {
             connect_timeout: Duration::from_secs(1),
             write_timeout: Duration::from_secs(1),
-            read_timeout: Duration::from_secs(1),
+            response_timeout: Duration::from_secs(1),
         },
     );
 
@@ -833,7 +834,7 @@ async fn first_request_lazily_connects_and_reports_connect_failure() {
     let timeouts = ModbusTcpTimeouts {
         connect_timeout: Duration::from_millis(50),
         write_timeout: Duration::from_millis(50),
-        read_timeout: Duration::from_millis(200),
+        response_timeout: Duration::from_millis(200),
     };
     let conn =
         ModbusTcpConnection::with_timeouts(addr.ip(), addr.port(), 1, 0, timeouts).with_retry(None);


### PR DESCRIPTION
## Summary
This PR improves the Modbus TCP transport to better handle bursty/concurrent traffic and slow serial-backed gateways.

## What changed
- add `ModbusTcpFlowControl` config for:
  - max in-flight requests
  - bounded queue depth / backpressure
  - queue timeout
  - transaction-id quarantine TTL
- move flow control into the actor so cloned handles can safely share one transport
- support concurrent in-flight requests with response matching by transaction ID
- retry transient transport failures and gateway-busy Modbus exceptions (`0x05`, `0x06`, `0x0A`, `0x0B`)
- add `QueueTimeout` and cloneable transport I/O errors to `ModbusError`
- keep response timeout scoped to on-wire time after the request is written
- document the new flow-control and retry behavior in the README

## Why
This makes the TCP client more robust when:
- multiple callers share one connection
- downstream RTU gateways only process requests serially
- short-lived disconnects or busy gateway responses occur under load

## Testing
- added integration coverage for:
  - bounded in-flight behavior
  - queue timeout / backpressure
  - concurrent request routing
  - gateway-busy retry behavior
  - retry/reconnect scenarios after transport failures