### PR TITLE
feat(tcp): support DNS host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ let connection = ModbusTcpConnection::with_config(
         response_timeout: Duration::from_secs(2),
     },
     ModbusTcpFlowControl::serial_gateway(),
-)
+)?
 .with_retry(Some(ModbusTcpRetry {
     initial_delay: Duration::from_millis(100),
     max_elapsed: Duration::from_secs(1),

--- a/README.md
+++ b/README.md
@@ -45,14 +45,12 @@ tiny-mb = "0.1.0"
 Create a typed request and send it over Modbus TCP:
 
 ```rust
-use std::net::{IpAddr, Ipv4Addr};
-
 use tiny_mb::tcp::ModbusTcpConnection;
 use tiny_mb::{ModbusRequest, ModbusResponse};
 
 #[tokio::main]
 async fn main() -> Result<(), tiny_mb::ModbusError> {
-    let connection = ModbusTcpConnection::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 502, 1, 1);
+    let connection = ModbusTcpConnection::new("127.0.0.1", 502, 1, 1);
 
     let response = connection
         .send_message(&ModbusRequest::ReadHoldingRegisters {
@@ -74,9 +72,10 @@ async fn main() -> Result<(), tiny_mb::ModbusError> {
 }
 ```
 
-The TCP client opens connections lazily, retries short-lived I/O failures, and can reuse the
-same socket across multiple requests. Internally, cloned handles send commands over a bounded
-channel to one actor task that owns the socket and MBAP codec; this provides backpressure under
+The TCP client accepts host names or numeric IP addresses, opens connections lazily, retries
+short-lived I/O failures, and can reuse the same socket across multiple requests. Internally,
+cloned handles send commands over a bounded channel to one actor task that owns the socket and
+MBAP codec; this provides backpressure under
 burst load. Cloned handles, including those returned by `with_unit_id`, may issue requests
 concurrently; responses are matched by MBAP transaction ID. Writes are serialized by the actor and
 a cancellation in one caller cannot interrupt a partially written Modbus TCP frame.
@@ -91,13 +90,12 @@ The write timeout covers both sending the frame and flushing the socket. If you 
 construct the connection with `with_timeouts(...)`.
 
 ```rust
-use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpTimeouts};
 
 let connection = ModbusTcpConnection::with_config(
-    IpAddr::V4(Ipv4Addr::LOCALHOST),
+    "localhost",
     502,
     1,
     1,

--- a/examples/concurrent_clients.rs
+++ b/examples/concurrent_clients.rs
@@ -7,7 +7,6 @@
 //! `cargo run --example concurrent_clients`.
 
 use std::error::Error;
-use std::net::{IpAddr, Ipv4Addr};
 
 use tiny_mb::ModbusRequest;
 use tiny_mb::tcp::ModbusTcpConnection;
@@ -15,7 +14,7 @@ use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let connection = ModbusTcpConnection::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 502, 1, 0);
+    let connection = ModbusTcpConnection::new("127.0.0.1", 502, 1, 0);
     let mut tasks = Vec::new();
 
     for offset in 0..4 {

--- a/examples/modbus_cli.rs
+++ b/examples/modbus_cli.rs
@@ -5,7 +5,6 @@
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::error::Error;
-use std::net::IpAddr;
 use std::process;
 use tracing::info;
 use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
@@ -45,9 +44,9 @@ struct Cli {
         long = "address",
         global = true,
         default_value = "127.0.0.1",
-        help = "Target device IP address"
+        help = "Target device host name or IP address"
     )]
-    ip_address: IpAddr,
+    host: String,
 
     #[arg(
         short = 'p',
@@ -504,41 +503,41 @@ fn print_response(request: &ModbusRequest, response: ModbusResponse, output_form
 
 /// Formats a `ModbusError` with phase-specific guidance so the operator
 /// knows which stage failed and what to try next.
-fn format_error(error: &ModbusError, address: IpAddr, port: u16) -> String {
+fn format_error(error: &ModbusError, host: &str, port: u16) -> String {
     match error {
         ModbusError::ConnectError(e) => {
             format!(
-                "Connect failed ({address}:{port}): {e}\n\
+                "Connect failed ({host}:{port}): {e}\n\
                  Hint: verify the device is reachable and the port is correct."
             )
         }
         ModbusError::ConnectTimeout => {
             format!(
-                "Connect timed out ({address}:{port}).\n\
+                "Connect timed out ({host}:{port}).\n\
                  Hint: check network connectivity and firewall rules."
             )
         }
         ModbusError::WriteError(e) => {
             format!(
-                "Write failed ({address}:{port}): {e}\n\
+                "Write failed ({host}:{port}): {e}\n\
                  Hint: the TCP session may have been closed by the device. Retry the request."
             )
         }
         ModbusError::WriteTimeout => {
             format!(
-                "Write timed out ({address}:{port}).\n\
+                "Write timed out ({host}:{port}).\n\
                  Hint: the device may be unresponsive. Check the connection and retry."
             )
         }
         ModbusError::ReadError(e) => {
             format!(
-                "Read failed ({address}:{port}): {e}\n\
+                "Read failed ({host}:{port}): {e}\n\
                  Hint: the device may have dropped the connection after the request was sent."
             )
         }
         ModbusError::ReadTimeout => {
             format!(
-                "Read timed out ({address}:{port}).\n\
+                "Read timed out ({host}:{port}).\n\
                  Hint: the device accepted the connection but did not respond in time. \
                  Verify the unit ID and function are supported."
             )
@@ -571,17 +570,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!(
         "Connecting to {}:{} (unit_id={}, transaction_id={})",
-        cli.ip_address, cli.port, cli.unit_id, cli.transaction_id
+        cli.host, cli.port, cli.unit_id, cli.transaction_id
     );
     info!("{}", describe_request(&request));
 
     let connection =
-        ModbusTcpConnection::new(cli.ip_address, cli.port, cli.unit_id, cli.transaction_id);
+        ModbusTcpConnection::new(cli.host.clone(), cli.port, cli.unit_id, cli.transaction_id);
 
     connection
         .connect()
         .await
-        .map_err(|e| format_error(&e, cli.ip_address, cli.port))?;
+        .map_err(|e| format_error(&e, &cli.host, cli.port))?;
 
     match connection.send_message(&request).await {
         Ok(response) => print_response(&request, response, cli.output),
@@ -592,7 +591,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(error) => {
             eprintln!("Request: {}", describe_request(&request));
-            eprintln!("{}", format_error(&error, cli.ip_address, cli.port));
+            eprintln!("{}", format_error(&error, &cli.host, cli.port));
             process::exit(1);
         }
     }
@@ -878,8 +877,7 @@ mod tests {
 
     #[test]
     fn format_error_connect_timeout_includes_hint() {
-        let addr: IpAddr = "192.168.1.10".parse().unwrap();
-        let msg = format_error(&ModbusError::ConnectTimeout, addr, 502);
+        let msg = format_error(&ModbusError::ConnectTimeout, "192.168.1.10", 502);
         assert!(msg.contains("Connect timed out"));
         assert!(msg.contains("192.168.1.10:502"));
         assert!(msg.contains("Hint"));
@@ -887,8 +885,7 @@ mod tests {
 
     #[test]
     fn format_error_read_timeout_includes_hint() {
-        let addr: IpAddr = "10.0.0.1".parse().unwrap();
-        let msg = format_error(&ModbusError::ReadTimeout, addr, 502);
+        let msg = format_error(&ModbusError::ReadTimeout, "10.0.0.1", 502);
         assert!(msg.contains("Read timed out"));
         assert!(msg.contains("10.0.0.1:502"));
         assert!(msg.contains("unit ID"));
@@ -896,8 +893,7 @@ mod tests {
 
     #[test]
     fn format_error_write_timeout_includes_hint() {
-        let addr: IpAddr = "10.0.0.1".parse().unwrap();
-        let msg = format_error(&ModbusError::WriteTimeout, addr, 502);
+        let msg = format_error(&ModbusError::WriteTimeout, "10.0.0.1", 502);
         assert!(msg.contains("Write timed out"));
         assert!(msg.contains("Hint"));
     }
@@ -946,7 +942,7 @@ mod tests {
             "16000",
         ]);
 
-        assert_eq!(cli.ip_address, "192.168.0.89".parse::<IpAddr>().unwrap());
+        assert_eq!(cli.host, "192.168.0.89");
         match cli.command {
             Command::Write { operation } => match operation {
                 WriteOperation::Register(args) => {

--- a/src/tcp/actor.rs
+++ b/src/tcp/actor.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashMap;
 use std::io;
-use std::net::IpAddr;
 use std::sync::Arc;
 
 use futures_util::{SinkExt, StreamExt, future::poll_fn};
@@ -65,7 +64,7 @@ struct PendingEntry {
 /// Actor that owns the TCP socket, transaction ids, and pending response map.
 #[derive(Debug)]
 pub(crate) struct Actor {
-    address: IpAddr,
+    host: String,
     port: u16,
     timeouts: ModbusTcpTimeouts,
     flow: ModbusTcpFlowControl,
@@ -83,7 +82,7 @@ pub(crate) struct Actor {
 impl Actor {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        address: IpAddr,
+        host: String,
         port: u16,
         timeouts: ModbusTcpTimeouts,
         flow: ModbusTcpFlowControl,
@@ -93,7 +92,7 @@ impl Actor {
         connected_tx: watch::Sender<bool>,
     ) -> Self {
         Self {
-            address,
+            host,
             port,
             timeouts,
             flow,
@@ -170,7 +169,7 @@ impl Actor {
             return Ok(());
         }
         let stream = ModbusTcpConnection::connect_stream(
-            self.address,
+            &self.host,
             self.port,
             self.timeouts.connect_timeout,
         )
@@ -384,7 +383,7 @@ mod tests {
         let (_req_tx, req_rx) = mpsc::channel(1);
         let (connected_tx, _connected_rx) = watch::channel(false);
         Actor::new(
-            "127.0.0.1".parse().unwrap(),
+            "127.0.0.1".to_string(),
             502,
             ModbusTcpTimeouts::default(),
             ModbusTcpFlowControl::default(),
@@ -520,7 +519,7 @@ mod tests {
         let (req_tx, req_rx) = mpsc::channel(2);
         let (connected_tx, _connected_rx) = watch::channel(false);
         let mut actor = Actor::new(
-            "127.0.0.1".parse().unwrap(),
+            "127.0.0.1".to_string(),
             502,
             ModbusTcpTimeouts::default(),
             ModbusTcpFlowControl {
@@ -582,7 +581,7 @@ mod tests {
         let (req_tx, req_rx) = mpsc::channel(2);
         let (connected_tx, _connected_rx) = watch::channel(false);
         let actor = Actor::new(
-            dead_addr.ip(),
+            dead_addr.ip().to_string(),
             dead_addr.port(),
             ModbusTcpTimeouts {
                 connect_timeout: Duration::from_millis(200),
@@ -717,7 +716,7 @@ mod tests {
         let (connected_tx, connected_rx) = watch::channel(false);
         drop(connected_rx);
         let mut actor = Actor::new(
-            addr.ip(),
+            addr.ip().to_string(),
             addr.port(),
             ModbusTcpTimeouts::default(),
             ModbusTcpFlowControl::default(),
@@ -836,7 +835,7 @@ mod tests {
         let (_req_tx, req_rx) = mpsc::channel(1);
         let (connected_tx, connected_rx) = watch::channel(true);
         let mut actor = Actor::new(
-            "127.0.0.1".parse().unwrap(),
+            "127.0.0.1".to_string(),
             502,
             ModbusTcpTimeouts {
                 connect_timeout: Duration::from_secs(1),
@@ -884,7 +883,7 @@ mod tests {
 
     async fn assert_next_request_reconnects(actor: &mut Actor) {
         let reconnect_addr = spawn_one_response_server().await;
-        actor.address = reconnect_addr.ip();
+        actor.host = reconnect_addr.ip().to_string();
         actor.port = reconnect_addr.port();
         let (reply, response) = oneshot::channel();
 

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -4,7 +4,6 @@
 //! Public Modbus TCP connection handle and request orchestration.
 
 use std::io;
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -41,10 +40,13 @@ pub struct ModbusTcpConnection {
 
 impl ModbusTcpConnection {
     /// Creates a connection handle with default connect, write, and read timeouts.
+    ///
+    /// `host` may be a DNS name or numeric IP address and is resolved whenever
+    /// the actor opens a TCP connection.
     #[must_use]
-    pub fn new(address: IpAddr, port: u16, unit_id: u8, transaction_id: u16) -> Self {
+    pub fn new(host: impl Into<String>, port: u16, unit_id: u8, transaction_id: u16) -> Self {
         Self::with_timeouts(
-            address,
+            host,
             port,
             unit_id,
             transaction_id,
@@ -53,16 +55,19 @@ impl ModbusTcpConnection {
     }
 
     /// Creates a connection handle with explicit timeout settings.
+    ///
+    /// `host` may be a DNS name or numeric IP address and is resolved whenever
+    /// the actor opens a TCP connection.
     #[must_use]
     pub fn with_timeouts(
-        address: IpAddr,
+        host: impl Into<String>,
         port: u16,
         unit_id: u8,
         transaction_id: u16,
         timeouts: ModbusTcpTimeouts,
     ) -> Self {
         Self::with_config(
-            address,
+            host,
             port,
             unit_id,
             transaction_id,
@@ -73,6 +78,9 @@ impl ModbusTcpConnection {
 
     /// Creates a connection handle with explicit timeout and flow-control settings.
     ///
+    /// `host` may be a DNS name or numeric IP address and is resolved whenever
+    /// the actor opens a TCP connection.
+    ///
     /// # Panics
     ///
     /// Panics if `flow_control` violates [`ModbusTcpFlowControl::validate`].
@@ -82,7 +90,7 @@ impl ModbusTcpConnection {
     #[must_use]
     #[allow(clippy::expect_used)]
     pub fn with_config(
-        address: IpAddr,
+        host: impl Into<String>,
         port: u16,
         unit_id: u8,
         transaction_id: u16,
@@ -93,7 +101,7 @@ impl ModbusTcpConnection {
             .validate()
             .expect("invalid Modbus TCP flow-control configuration");
         Self::spawn_with_config(
-            address,
+            host.into(),
             port,
             unit_id,
             transaction_id,
@@ -104,7 +112,7 @@ impl ModbusTcpConnection {
     }
 
     fn spawn_with_config(
-        address: IpAddr,
+        host: String,
         port: u16,
         unit_id: u8,
         transaction_id: u16,
@@ -115,7 +123,7 @@ impl ModbusTcpConnection {
         let (ctrl_tx, ctrl_rx) = mpsc::channel(control_channel_capacity());
         let (connected_tx, connected) = watch::channel(false);
         let actor = Actor::new(
-            address,
+            host,
             port,
             timeouts,
             flow_control,
@@ -140,14 +148,14 @@ impl ModbusTcpConnection {
 
     #[cfg(test)]
     fn spawn_with_timeouts(
-        address: IpAddr,
+        host: impl Into<String>,
         port: u16,
         unit_id: u8,
         transaction_id: u16,
         timeouts: ModbusTcpTimeouts,
     ) -> (Self, JoinHandle<()>) {
         Self::spawn_with_config(
-            address,
+            host.into(),
             port,
             unit_id,
             transaction_id,
@@ -177,16 +185,15 @@ impl ModbusTcpConnection {
     }
 
     pub(crate) async fn connect_stream(
-        address: IpAddr,
+        host: &str,
         port: u16,
         connect_timeout: Duration,
     ) -> Result<TcpStream, ModbusError> {
-        let server_addr = format!("{address}:{port}");
-        let stream = timeout(connect_timeout, TcpStream::connect(&server_addr))
+        let stream = timeout(connect_timeout, TcpStream::connect((host, port)))
             .await
             .map_err(|_| ModbusError::ConnectTimeout)?
             .map_err(|error| ModbusError::ConnectError(Arc::new(error)))?;
-        debug!(server_addr, "connected to Modbus TCP server");
+        debug!(host, port, "connected to Modbus TCP server");
         Ok(stream)
     }
 
@@ -340,7 +347,7 @@ mod tests {
     #[tokio::test]
     async fn connection_starts_disconnected_and_connect_sets_connected() {
         let addr = accept_and_hold_server().await;
-        let connection = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+        let connection = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
         assert!(!connection.is_connected().await);
         connection.connect().await.unwrap();
         assert!(connection.is_connected().await);
@@ -349,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn disconnect_is_idempotent_and_clears_connected() {
         let addr = accept_and_hold_server().await;
-        let connection = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+        let connection = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
         connection.connect().await.unwrap();
         connection.disconnect().await;
         connection.disconnect().await;
@@ -357,11 +364,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connect_accepts_domain_style_host() {
+        let addr = accept_and_hold_server().await;
+        let connection = ModbusTcpConnection::new("localhost", addr.port(), 1, 0);
+
+        connection.connect().await.unwrap();
+
+        assert!(connection.is_connected().await);
+    }
+
+    #[tokio::test]
     async fn actor_exits_after_handles_drop_while_disconnected() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let (connection, actor_task) = ModbusTcpConnection::spawn_with_timeouts(
-            addr.ip(),
+            addr.ip().to_string(),
             addr.port(),
             1,
             0,
@@ -382,7 +399,7 @@ mod tests {
     async fn actor_exits_after_handles_drop_while_connected() {
         let addr = accept_and_hold_server().await;
         let (connection, actor_task) = ModbusTcpConnection::spawn_with_timeouts(
-            addr.ip(),
+            addr.ip().to_string(),
             addr.port(),
             1,
             0,
@@ -403,8 +420,7 @@ mod tests {
 
     #[tokio::test]
     async fn with_unit_id_keeps_retry_policy_and_overrides_unit() {
-        let connection =
-            ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0).with_retry(None);
+        let connection = ModbusTcpConnection::new("127.0.0.1", 502, 1, 0).with_retry(None);
         let child = connection.with_unit_id(7);
         assert_eq!(child.retry, None);
         assert_eq!(child.unit_id, 7);
@@ -571,8 +587,9 @@ mod tests {
             write_timeout: Duration::from_millis(50),
             response_timeout: Duration::from_millis(50),
         };
-        let connection = ModbusTcpConnection::with_timeouts(addr.ip(), addr.port(), 1, 0, timeouts)
-            .with_retry(None);
+        let connection =
+            ModbusTcpConnection::with_timeouts(addr.ip().to_string(), addr.port(), 1, 0, timeouts)
+                .with_retry(None);
         assert!(matches!(
             connection.connect().await,
             Err(ModbusError::ConnectError(_) | ModbusError::ConnectTimeout)

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -66,14 +66,15 @@ impl ModbusTcpConnection {
         transaction_id: u16,
         timeouts: ModbusTcpTimeouts,
     ) -> Self {
-        Self::with_config(
-            host,
+        Self::spawn_with_config(
+            host.into(),
             port,
             unit_id,
             transaction_id,
             timeouts,
             ModbusTcpFlowControl::default(),
         )
+        .0
     }
 
     /// Creates a connection handle with explicit timeout and flow-control settings.
@@ -81,14 +82,13 @@ impl ModbusTcpConnection {
     /// `host` may be a DNS name or numeric IP address and is resolved whenever
     /// the actor opens a TCP connection.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `flow_control` violates [`ModbusTcpFlowControl::validate`].
-    /// Flow control is validated synchronously because its queue depth is needed
-    /// before the actor task and request channel are spawned; retry policies are
-    /// validated later when a request starts.
-    #[must_use]
-    #[allow(clippy::expect_used)]
+    /// Returns [`ModbusError::ValidationError`] if `flow_control` violates
+    /// [`ModbusTcpFlowControl::validate`]. Flow control is validated
+    /// synchronously because its queue depth is needed before the actor task and
+    /// request channel are spawned; retry policies are validated later when a
+    /// request starts.
     pub fn with_config(
         host: impl Into<String>,
         port: u16,
@@ -96,11 +96,9 @@ impl ModbusTcpConnection {
         transaction_id: u16,
         timeouts: ModbusTcpTimeouts,
         flow_control: ModbusTcpFlowControl,
-    ) -> Self {
-        flow_control
-            .validate()
-            .expect("invalid Modbus TCP flow-control configuration");
-        Self::spawn_with_config(
+    ) -> Result<Self, ModbusError> {
+        flow_control.validate()?;
+        Ok(Self::spawn_with_config(
             host.into(),
             port,
             unit_id,
@@ -108,7 +106,7 @@ impl ModbusTcpConnection {
             timeouts,
             flow_control,
         )
-        .0
+        .0)
     }
 
     fn spawn_with_config(

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -89,7 +89,7 @@ async fn send_read_coils_success() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -124,7 +124,7 @@ async fn send_write_single_register_success() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::WriteSingleRegister {
@@ -154,7 +154,7 @@ async fn transaction_id_increments() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 100);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 100);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -184,7 +184,7 @@ async fn concurrent_in_flight_requests_are_matched_out_of_order() {
         stream.write_all(&first_response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -259,7 +259,7 @@ async fn server_disconnects_on_write() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
         .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
     conn.connect().await.unwrap();
 
@@ -322,7 +322,7 @@ async fn server_disconnects_on_header_read() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
         .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
     conn.connect().await.unwrap();
 
@@ -368,7 +368,7 @@ async fn server_sends_invalid_mbap_length() {
         second_stream.write_all(&response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -398,7 +398,7 @@ async fn send_messages_across_multiple_unit_ids_on_one_connection() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -433,7 +433,7 @@ async fn send_message_returns_exception_response_as_typed_error() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -465,7 +465,7 @@ async fn send_message_returns_protocol_id_mismatch_as_typed_error() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -495,7 +495,7 @@ async fn send_message_returns_unit_id_mismatch_as_typed_error() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
 
     let request = ModbusRequest::ReadCoils {
@@ -518,7 +518,7 @@ async fn send_message_returns_read_timeout_from_slow_server() {
     let addr = spawn_slow_server(Duration::from_millis(200)).await.unwrap();
 
     let conn = ModbusTcpConnection::with_timeouts(
-        addr.ip(),
+        addr.ip().to_string(),
         addr.port(),
         1,
         0,
@@ -560,7 +560,7 @@ async fn stray_response_with_unknown_tid_is_ignored() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
         quantity: 2,
@@ -594,7 +594,7 @@ async fn reader_death_drains_pending_and_next_call_reconnects() {
     });
 
     let conn = ModbusTcpConnection::with_timeouts(
-        addr.ip(),
+        addr.ip().to_string(),
         addr.port(),
         1,
         0,
@@ -645,7 +645,7 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
     });
 
     let conn = ModbusTcpConnection::with_config(
-        addr.ip(),
+        addr.ip().to_string(),
         addr.port(),
         1,
         0,
@@ -703,7 +703,7 @@ async fn serial_gateway_never_exceeds_one_in_flight_request() {
     });
 
     let conn = ModbusTcpConnection::with_config(
-        addr.ip(),
+        addr.ip().to_string(),
         addr.port(),
         1,
         0,
@@ -757,7 +757,7 @@ async fn one_timed_out_tid_is_quarantined_while_sibling_and_socket_survive() {
     });
 
     let conn = ModbusTcpConnection::with_config(
-        addr.ip(),
+        addr.ip().to_string(),
         addr.port(),
         1,
         0,
@@ -825,7 +825,7 @@ async fn gateway_busy_exception_retries_when_enabled() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
         .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
@@ -856,11 +856,12 @@ async fn gateway_busy_exception_does_not_retry_when_disabled() {
     })
     .await;
 
-    let conn =
-        ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0).with_retry(Some(ModbusTcpRetry {
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0).with_retry(Some(
+        ModbusTcpRetry {
             retry_gateway_busy: false,
             ..fast_retry(Duration::from_millis(500), None)
-        }));
+        },
+    ));
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -890,7 +891,7 @@ async fn send_message_with_disabled_retry_does_not_retry() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0).with_retry(None);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0).with_retry(None);
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -917,7 +918,7 @@ async fn disabled_retry_still_reconnects_on_next_call() {
         stream.write_all(&response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0).with_retry(None);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0).with_retry(None);
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -948,7 +949,7 @@ async fn send_message_with_custom_retry_honors_max_elapsed() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
         .with_retry(Some(fast_retry(Duration::from_millis(100), None)));
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
@@ -981,7 +982,7 @@ async fn send_message_with_max_times_caps_attempts() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0)
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
         .with_retry(Some(fast_retry(Duration::from_secs(5), Some(2))));
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
@@ -998,12 +999,10 @@ async fn send_message_with_max_times_caps_attempts() {
 
 #[tokio::test]
 async fn invalid_retry_policy_surfaces_as_validation_error() {
-    let conn = ModbusTcpConnection::new("127.0.0.1".parse().unwrap(), 502, 1, 0).with_retry(Some(
-        ModbusTcpRetry {
-            initial_delay: Duration::ZERO,
-            ..ModbusTcpRetry::default()
-        },
-    ));
+    let conn = ModbusTcpConnection::new("127.0.0.1", 502, 1, 0).with_retry(Some(ModbusTcpRetry {
+        initial_delay: Duration::ZERO,
+        ..ModbusTcpRetry::default()
+    }));
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -1033,7 +1032,8 @@ async fn first_request_lazily_connects_and_reports_connect_failure() {
         response_timeout: Duration::from_millis(200),
     };
     let conn =
-        ModbusTcpConnection::with_timeouts(addr.ip(), addr.port(), 1, 0, timeouts).with_retry(None);
+        ModbusTcpConnection::with_timeouts(addr.ip().to_string(), addr.port(), 1, 0, timeouts)
+            .with_retry(None);
 
     let request = ModbusRequest::ReadHoldingRegisters {
         starting_address: 0,
@@ -1057,7 +1057,7 @@ async fn connect_is_idempotent_while_already_connected() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip(), addr.port(), 1, 0);
+    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
     conn.connect().await.unwrap();
     // The second connect must take the already-connected fast path and stay open.
     conn.connect().await.unwrap();

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -655,7 +655,8 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
             response_timeout: Duration::from_secs(1),
         },
         ModbusTcpFlowControl::serial_gateway(),
-    );
+    )
+    .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -713,7 +714,8 @@ async fn serial_gateway_never_exceeds_one_in_flight_request() {
             response_timeout: Duration::from_secs(1),
         },
         ModbusTcpFlowControl::serial_gateway(),
-    );
+    )
+    .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -772,6 +774,7 @@ async fn one_timed_out_tid_is_quarantined_while_sibling_and_socket_survive() {
             ..ModbusTcpFlowControl::default()
         },
     )
+    .unwrap()
     .with_retry(None);
     let slow_request = ModbusRequest::ReadCoils {
         starting_address: 0,


### PR DESCRIPTION
Store TCP targets as host strings and resolve them whenever the actor connects so reconnects pick up DNS changes. Update the CLI, examples, tests, and README to accept host names as well as numeric addresses.

Also removes the expect that slipped through in the last PR.