### PR TITLE
refactor(tcp)!: split Modbus TCP construction into socket and live connection phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Small Rust Modbus library with typed request/response PDUs and a reusable Modbus
   - write multiple coils
   - write multiple registers
 - Modbus TCP transport with:
-  - lazy connect or explicit `connect()`
+  - two-phase `ModbusTcpSocket` → `ModbusTcpConnection` construction
+  - eager, fallible first TCP connect followed by lazy reconnect after transport failures
   - reusable actor-owned connections with bounded request-channel backpressure
   - configurable in-flight window for slow gateway-backed buses
   - retry of transient I/O failures and gateway-busy exception responses
@@ -50,7 +51,7 @@ use tiny_mb::{ModbusRequest, ModbusResponse};
 
 #[tokio::main]
 async fn main() -> Result<(), tiny_mb::ModbusError> {
-    let connection = ModbusTcpConnection::new("127.0.0.1", 502, 1, 1);
+    let connection = ModbusTcpConnection::connect("127.0.0.1", 502, 1).await?;
 
     let response = connection
         .send_message(&ModbusRequest::ReadHoldingRegisters {
@@ -72,12 +73,13 @@ async fn main() -> Result<(), tiny_mb::ModbusError> {
 }
 ```
 
-The TCP client accepts host names or numeric IP addresses, opens connections lazily, retries
-short-lived I/O failures, and can reuse the same socket across multiple requests. Internally,
-cloned handles send commands over a bounded channel to one actor task that owns the socket and
-MBAP codec; this provides backpressure under
-burst load. Cloned handles, including those returned by `with_unit_id`, may issue requests
-concurrently; responses are matched by MBAP transaction ID. Writes are serialized by the actor and
+The TCP client accepts host names or numeric IP addresses. `ModbusTcpConnection::connect(...)`
+is async and fallible: it opens the first TCP socket eagerly, then the live actor handle retries
+short-lived I/O failures and reconnects lazily after transport teardown. Internally, cloned
+handles send commands over a bounded channel to one actor task that owns the socket and MBAP codec;
+this provides backpressure under burst load. Cloned handles, including those returned by
+`with_unit_id`, may issue requests concurrently; responses are matched by MBAP transaction ID.
+Writes are serialized by the actor and
 a cancellation in one caller cannot interrupt a partially written Modbus TCP frame.
 
 Use `send_message_with_unit_id` or `with_unit_id(...)` when talking to multiple devices behind one
@@ -85,39 +87,38 @@ Modbus TCP gateway.
 
 ## Timeouts and retries
 
-`ModbusTcpConnection::new(...)` uses sensible defaults for connect, write, and read timeouts.
+`ModbusTcpConnection::connect(...)` uses sensible defaults for connect, write, and response timeouts.
 The write timeout covers both sending the frame and flushing the socket. If you need custom limits,
-construct the connection with `with_timeouts(...)`.
+configure a `ModbusTcpSocket` before calling `connect().await`.
 
 ```rust
 use std::time::Duration;
 
-use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpTimeouts};
+use tiny_mb::tcp::{ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpSocket, ModbusTcpTimeouts};
 
-let connection = ModbusTcpConnection::with_config(
-    "localhost",
-    502,
-    1,
-    1,
-    ModbusTcpTimeouts {
+let connection = ModbusTcpSocket::new("localhost", 502, 1)
+    .with_timeouts(ModbusTcpTimeouts {
         connect_timeout: Duration::from_secs(2),
         write_timeout: Duration::from_secs(2),
         response_timeout: Duration::from_secs(2),
-    },
-    ModbusTcpFlowControl::serial_gateway(),
-)?
-.with_retry(Some(ModbusTcpRetry {
-    initial_delay: Duration::from_millis(100),
-    max_elapsed: Duration::from_secs(1),
-    ..ModbusTcpRetry::default()
-}));
+    })
+    .with_flow_control(ModbusTcpFlowControl::serial_gateway())
+    .with_retry(Some(ModbusTcpRetry {
+        initial_delay: Duration::from_millis(100),
+        max_elapsed: Duration::from_secs(1),
+        ..ModbusTcpRetry::default()
+    }))
+    .connect()
+    .await?;
 ```
 
-Flow control is actor-owned: `ModbusTcpFlowControl::max_in_flight` caps requests on the wire,
-and `max_queue_depth` is the bounded backlog that applies backpressure to callers. Use
+Flow control is actor-owned and validated when `ModbusTcpSocket::connect` is awaited:
+`ModbusTcpFlowControl::max_in_flight` caps requests on the wire, and `max_queue_depth` is the
+bounded backlog that applies backpressure to callers. Invalid flow-control settings return
+`ModbusError::ValidationError` from socket `connect`. Use
 `ModbusTcpFlowControl::serial_gateway()` for RTU gateways that drain one serial bus sequentially.
 Queue wait is bounded by `queue_timeout`; the `response_timeout` clock starts only after the actor
-successfully writes the frame to the socket. A single response timeout now fails that transaction,
+successfully writes the frame to the socket. A single response timeout fails that transaction,
 quarantines its transaction ID to avoid late-response aliasing, and keeps the TCP socket open.
 
 By default, transient TCP connect/write/read/queue failures and gateway-busy exception responses

--- a/examples/concurrent_clients.rs
+++ b/examples/concurrent_clients.rs
@@ -14,7 +14,7 @@ use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let connection = ModbusTcpConnection::new("127.0.0.1", 502, 1, 0);
+    let connection = ModbusTcpConnection::connect("127.0.0.1", 502, 1).await?;
     let mut tasks = Vec::new();
 
     for offset in 0..4 {

--- a/examples/modbus_cli.rs
+++ b/examples/modbus_cli.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::Sub
 use tiny_mb::ModbusError;
 use tiny_mb::ModbusRequest;
 use tiny_mb::ModbusResponse;
-use tiny_mb::tcp::ModbusTcpConnection;
+use tiny_mb::tcp::ModbusTcpSocket;
 
 // ---------------------------------------------------------------------------
 // CLI definition
@@ -574,10 +574,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
     info!("{}", describe_request(&request));
 
-    let connection =
-        ModbusTcpConnection::new(cli.host.clone(), cli.port, cli.unit_id, cli.transaction_id);
-
-    connection
+    let connection = ModbusTcpSocket::new(cli.host.clone(), cli.port, cli.unit_id)
+        .with_initial_transaction_id(cli.transaction_id)
         .connect()
         .await
         .map_err(|e| format_error(&e, &cli.host, cli.port))?;

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -14,10 +14,12 @@ mod codec;
 mod flow;
 mod frame;
 mod retry;
+mod socket;
 mod timeouts;
 
 mod tcp_connection;
 pub use flow::ModbusTcpFlowControl;
 pub use retry::ModbusTcpRetry;
+pub use socket::ModbusTcpSocket;
 pub use tcp_connection::ModbusTcpConnection;
 pub use timeouts::ModbusTcpTimeouts;

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -3,10 +3,14 @@
 
 //! Modbus TCP framing and transport helpers.
 //!
-//! The public surface exports the reusable connection handle plus its retry and
-//! timeout configuration. Internal submodules keep ADU/MBAP frame construction,
-//! actor-based socket ownership, MBAP codec framing, and retry/timeout
-//! configuration separated by concern.
+//! The public construction surface is split into two phases:
+//! [`ModbusTcpSocket`] stores configurable settings without opening a network
+//! connection, then [`ModbusTcpSocket::connect`] validates those settings,
+//! eagerly opens the first TCP connection, and returns a live
+//! [`ModbusTcpConnection`] actor handle. [`ModbusTcpConnection::connect`] is the
+//! default-configuration shortcut. Internal submodules keep ADU/MBAP frame
+//! construction, actor-based socket ownership, MBAP codec framing, and
+//! retry/timeout configuration separated by concern.
 
 mod actor;
 mod adu;

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -12,14 +12,17 @@ use crate::error::ModbusError;
 
 /// Exponential retry policy used by [`crate::tcp::ModbusTcpConnection`].
 ///
-/// The policy applies to one `send_message` or `send_message_with_unit_id` call.
-/// Each retry performs a fresh connect/write/read attempt after the connection
-/// has been invalidated by the transient failure that triggered the retry.
+/// Configure the policy during the socket phase with
+/// [`crate::tcp::ModbusTcpSocket::with_retry`]. The policy applies to one
+/// `send_message` or `send_message_with_unit_id` call on the resulting live
+/// connection. Each retry performs a fresh connect/write/read attempt after the
+/// connection has been invalidated by the transient failure that triggered the
+/// retry.
 ///
 /// The [`Default::default`] policy starts at 500 ms, multiplies delays by
 /// 1.5, adds jitter, and retries until 2 s of total retry delay has elapsed.
 /// Set [`Self::max_times`] when you also need to cap the number of retry
-/// attempts. Pass `None` to [`crate::tcp::ModbusTcpConnection::with_retry`] to
+/// attempts. Pass `None` to [`crate::tcp::ModbusTcpSocket::with_retry`] to
 /// disable same-call retry entirely.
 ///
 /// # Retried errors

--- a/src/tcp/socket.rs
+++ b/src/tcp/socket.rs
@@ -4,6 +4,7 @@
 //! Configurable Modbus TCP socket phase.
 
 use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
 
 use crate::error::ModbusError;
 use crate::tcp::actor::{Actor, ControlCommand, RequestCommand, control_channel_capacity};
@@ -109,7 +110,7 @@ impl ModbusTcpSocket {
     /// the warm-up command.
     pub async fn connect(self) -> Result<ModbusTcpConnection, ModbusError> {
         self.flow_control.validate()?;
-        let connection = self.spawn_actor();
+        let (connection, _actor_task) = self.spawn_actor();
         let (ack, reply) = oneshot::channel();
         connection
             .ctrl_tx
@@ -120,7 +121,7 @@ impl ModbusTcpSocket {
         Ok(connection)
     }
 
-    pub(crate) fn spawn_actor(self) -> ModbusTcpConnection {
+    pub(crate) fn spawn_actor(self) -> (ModbusTcpConnection, JoinHandle<()>) {
         let (req_tx, req_rx) = mpsc::channel::<RequestCommand>(self.flow_control.max_queue_depth);
         let (ctrl_tx, ctrl_rx) = mpsc::channel(control_channel_capacity());
         let (connected_tx, connected) = watch::channel(false);
@@ -134,15 +135,16 @@ impl ModbusTcpSocket {
             req_rx,
             connected_tx,
         );
-        tokio::spawn(actor.run());
-        ModbusTcpConnection::from_actor_parts(
+        let actor_task = tokio::spawn(actor.run());
+        let connection = ModbusTcpConnection::from_actor_parts(
             req_tx,
             ctrl_tx,
             self.unit_id,
             connected,
             self.flow_control.queue_timeout,
             self.retry,
-        )
+        );
+        (connection, actor_task)
     }
 }
 

--- a/src/tcp/socket.rs
+++ b/src/tcp/socket.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 tinymb contributors
+
+//! Configurable Modbus TCP socket phase.
+
+use tokio::sync::{mpsc, oneshot, watch};
+
+use crate::error::ModbusError;
+use crate::tcp::actor::{Actor, ControlCommand, RequestCommand, control_channel_capacity};
+use crate::tcp::flow::ModbusTcpFlowControl;
+use crate::tcp::retry::ModbusTcpRetry;
+use crate::tcp::tcp_connection::{ModbusTcpConnection, actor_terminated_error};
+use crate::tcp::timeouts::ModbusTcpTimeouts;
+
+/// Configurable Modbus TCP connection phase.
+///
+/// A socket stores construction-time settings as plain configuration. Creating
+/// or modifying a socket does not spawn the background actor, resolve `host`, or
+/// open a TCP connection. Call [`ModbusTcpSocket::connect`] to validate the
+/// configuration, spawn the actor, eagerly open the first TCP connection, and
+/// receive a live [`ModbusTcpConnection`].
+#[derive(Clone, Debug)]
+pub struct ModbusTcpSocket {
+    host: String,
+    port: u16,
+    unit_id: u8,
+    transaction_id: u16,
+    timeouts: ModbusTcpTimeouts,
+    flow_control: ModbusTcpFlowControl,
+    retry: Option<ModbusTcpRetry>,
+}
+
+impl ModbusTcpSocket {
+    /// Creates a configurable socket with default construction settings.
+    ///
+    /// `host` may be a DNS name or numeric IP address and is not resolved until
+    /// [`Self::connect`] is awaited. `port` is the TCP port used for every actor
+    /// dial, and `unit_id` is the default Modbus unit id used by the live
+    /// connection. The initial transaction-id seed defaults to `1`; timeouts,
+    /// flow control, and retry use their documented defaults.
+    #[must_use]
+    pub fn new(host: impl Into<String>, port: u16, unit_id: u8) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            unit_id,
+            transaction_id: 1,
+            timeouts: ModbusTcpTimeouts::default(),
+            flow_control: ModbusTcpFlowControl::default(),
+            retry: Some(ModbusTcpRetry::default()),
+        }
+    }
+
+    /// Overrides the connect, write, and response timeouts used by the actor.
+    ///
+    /// `timeouts` is stored on the configurable socket and handed to the actor
+    /// when [`Self::connect`] is awaited. Returns the updated socket.
+    #[must_use]
+    pub fn with_timeouts(mut self, timeouts: ModbusTcpTimeouts) -> Self {
+        self.timeouts = timeouts;
+        self
+    }
+
+    /// Overrides the actor flow-control settings.
+    ///
+    /// `flow_control` configures queue depth, in-flight request capacity, queue
+    /// timeout, and quarantine lifetime. It is validated when [`Self::connect`]
+    /// is awaited. Returns the updated socket.
+    #[must_use]
+    pub fn with_flow_control(mut self, flow_control: ModbusTcpFlowControl) -> Self {
+        self.flow_control = flow_control;
+        self
+    }
+
+    /// Overrides the same-call retry policy used by the live connection.
+    ///
+    /// `retry` is copied into the live [`ModbusTcpConnection`]. Pass `None` to
+    /// disable retry for sends through that handle. Returns the updated socket.
+    #[must_use]
+    pub fn with_retry(mut self, retry: Option<ModbusTcpRetry>) -> Self {
+        self.retry = retry;
+        self
+    }
+
+    /// Overrides the MBAP transaction-id counter seed.
+    ///
+    /// `transaction_id` is the id used by the first request after connection,
+    /// with subsequent requests incrementing from it with wrap-around. Returns
+    /// the updated socket.
+    #[must_use]
+    pub fn with_initial_transaction_id(mut self, transaction_id: u16) -> Self {
+        self.transaction_id = transaction_id;
+        self
+    }
+
+    /// Spawns the actor, eagerly opens the first TCP connection, and returns a live handle.
+    ///
+    /// Flow control is validated before channels are allocated. On success, the
+    /// actor is spawned and the existing actor control path is used to perform
+    /// an eager warm-up connect before the live [`ModbusTcpConnection`] is
+    /// returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModbusError::ValidationError`] if flow-control settings are
+    /// invalid. Returns [`ModbusError::ConnectError`] or
+    /// [`ModbusError::ConnectTimeout`] if the first TCP connection cannot be
+    /// opened, or a transport error if the actor terminates before acknowledging
+    /// the warm-up command.
+    pub async fn connect(self) -> Result<ModbusTcpConnection, ModbusError> {
+        self.flow_control.validate()?;
+        let connection = self.spawn_actor();
+        let (ack, reply) = oneshot::channel();
+        connection
+            .ctrl_tx
+            .send(ControlCommand::Connect { ack })
+            .await
+            .map_err(|_| actor_terminated_error())?;
+        reply.await.map_err(|_| actor_terminated_error())??;
+        Ok(connection)
+    }
+
+    pub(crate) fn spawn_actor(self) -> ModbusTcpConnection {
+        let (req_tx, req_rx) = mpsc::channel::<RequestCommand>(self.flow_control.max_queue_depth);
+        let (ctrl_tx, ctrl_rx) = mpsc::channel(control_channel_capacity());
+        let (connected_tx, connected) = watch::channel(false);
+        let actor = Actor::new(
+            self.host,
+            self.port,
+            self.timeouts,
+            self.flow_control,
+            self.transaction_id,
+            ctrl_rx,
+            req_rx,
+            connected_tx,
+        );
+        tokio::spawn(actor.run());
+        ModbusTcpConnection::from_actor_parts(
+            req_tx,
+            ctrl_tx,
+            self.unit_id,
+            connected,
+            self.flow_control.queue_timeout,
+            self.retry,
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    #[test]
+    fn new_stores_defaults_without_spawning() {
+        let socket = ModbusTcpSocket::new("localhost", 502, 7);
+
+        assert_eq!(socket.host, "localhost");
+        assert_eq!(socket.port, 502);
+        assert_eq!(socket.unit_id, 7);
+        assert_eq!(socket.transaction_id, 1);
+        assert_eq!(socket.timeouts, ModbusTcpTimeouts::default());
+        assert_eq!(socket.flow_control, ModbusTcpFlowControl::default());
+        assert_eq!(socket.retry, Some(ModbusTcpRetry::default()));
+    }
+
+    #[test]
+    fn modifiers_store_custom_settings() {
+        let timeouts = ModbusTcpTimeouts {
+            connect_timeout: Duration::from_millis(11),
+            write_timeout: Duration::from_millis(12),
+            response_timeout: Duration::from_millis(13),
+        };
+        let flow_control = ModbusTcpFlowControl {
+            max_in_flight: 2,
+            max_queue_depth: 3,
+            queue_timeout: Duration::from_millis(14),
+            quarantine_ttl: Duration::from_millis(15),
+        };
+        let retry = ModbusTcpRetry {
+            initial_delay: Duration::from_millis(1),
+            max_delay: Some(Duration::from_millis(2)),
+            multiplier: 1.5,
+            max_elapsed: Duration::from_millis(16),
+            max_times: Some(2),
+            jitter: false,
+            retry_gateway_busy: false,
+        };
+
+        let socket = ModbusTcpSocket::new("127.0.0.1", 502, 1)
+            .with_timeouts(timeouts)
+            .with_flow_control(flow_control)
+            .with_retry(Some(retry))
+            .with_initial_transaction_id(42);
+
+        assert_eq!(socket.timeouts, timeouts);
+        assert_eq!(socket.flow_control, flow_control);
+        assert_eq!(socket.retry, Some(retry));
+        assert_eq!(socket.transaction_id, 42);
+
+        let socket = socket.with_retry(None);
+        assert_eq!(socket.retry, None);
+    }
+
+    #[tokio::test]
+    async fn connect_success_returns_connected_handle() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let connection = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+            .connect()
+            .await
+            .unwrap();
+
+        assert!(connection.is_connected().await);
+    }
+
+    #[tokio::test]
+    async fn connect_validates_flow_control() {
+        let flow_control = ModbusTcpFlowControl {
+            max_in_flight: 0,
+            ..ModbusTcpFlowControl::default()
+        };
+
+        let result = ModbusTcpSocket::new("127.0.0.1", 502, 1)
+            .with_flow_control(flow_control)
+            .connect()
+            .await;
+
+        assert!(matches!(result, Err(ModbusError::ValidationError(_))));
+    }
+}

--- a/src/tcp/socket.rs
+++ b/src/tcp/socket.rs
@@ -17,9 +17,13 @@ use crate::tcp::timeouts::ModbusTcpTimeouts;
 ///
 /// A socket stores construction-time settings as plain configuration. Creating
 /// or modifying a socket does not spawn the background actor, resolve `host`, or
-/// open a TCP connection. Call [`ModbusTcpSocket::connect`] to validate the
-/// configuration, spawn the actor, eagerly open the first TCP connection, and
-/// receive a live [`ModbusTcpConnection`].
+/// open a TCP connection. Use [`Self::with_timeouts`] for connect/write/response
+/// deadlines, [`Self::with_flow_control`] for in-flight and queue limits,
+/// [`Self::with_retry`] for same-call send retry, and
+/// [`Self::with_initial_transaction_id`] when a diagnostic caller needs a custom
+/// MBAP transaction-id seed. Call [`ModbusTcpSocket::connect`] to validate flow
+/// control, spawn the actor, eagerly open the first TCP connection, consume the
+/// socket, and receive a live [`ModbusTcpConnection`].
 #[derive(Clone, Debug)]
 pub struct ModbusTcpSocket {
     host: String,

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -16,6 +16,7 @@ use crate::tcp::actor::{ControlCommand, RequestCommand};
 use crate::tcp::frame::MBAP_HEADER_LEN;
 use crate::tcp::retry::{ModbusTcpRetry, retry_transient};
 use crate::tcp::socket::ModbusTcpSocket;
+#[cfg(test)]
 use crate::tcp::timeouts::ModbusTcpTimeouts;
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError};
 

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -381,14 +381,14 @@ mod tests {
                 queue_deadline: tokio::time::Instant::now() + Duration::from_secs(1),
             })
             .unwrap();
-        let connection = ModbusTcpConnection {
+        let connection = ModbusTcpConnection::from_actor_parts(
             req_tx,
             ctrl_tx,
-            unit_id: 1,
+            1,
             connected,
-            queue_timeout: Duration::from_millis(10),
-            retry: None,
-        };
+            Duration::from_millis(10),
+            None,
+        );
 
         let result = timeout(
             Duration::from_millis(10),
@@ -411,14 +411,14 @@ mod tests {
         let (_connected_tx, connected) = watch::channel(false);
         drop(req_rx);
         drop(ctrl_rx);
-        ModbusTcpConnection {
+        ModbusTcpConnection::from_actor_parts(
             req_tx,
             ctrl_tx,
-            unit_id: 1,
+            1,
             connected,
-            queue_timeout: Duration::from_millis(50),
-            retry: None,
-        }
+            Duration::from_millis(50),
+            None,
+        )
     }
 
     /// Disconnecting a handle whose actor task has already stopped must return
@@ -461,14 +461,14 @@ mod tests {
         let (req_tx, _req_rx) = mpsc::channel(1);
         let (ctrl_tx, mut ctrl_rx) = mpsc::channel(1);
         let (_connected_tx, connected) = watch::channel(false);
-        let connection = ModbusTcpConnection {
+        let connection = ModbusTcpConnection::from_actor_parts(
             req_tx,
             ctrl_tx,
-            unit_id: 1,
+            1,
             connected,
-            queue_timeout: Duration::from_millis(50),
-            retry: None,
-        };
+            Duration::from_millis(50),
+            None,
+        );
         tokio::spawn(async move {
             if let Some(ControlCommand::Disconnect { ack }) = ctrl_rx.recv().await {
                 drop(ack);
@@ -485,14 +485,14 @@ mod tests {
         let (req_tx, mut req_rx) = mpsc::channel(1);
         let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
         let (_connected_tx, connected) = watch::channel(false);
-        let connection = ModbusTcpConnection {
+        let connection = ModbusTcpConnection::from_actor_parts(
             req_tx,
             ctrl_tx,
-            unit_id: 1,
+            1,
             connected,
-            queue_timeout: Duration::from_millis(50),
-            retry: None,
-        };
+            Duration::from_millis(50),
+            None,
+        );
         tokio::spawn(async move {
             if let Some(RequestCommand { reply, .. }) = req_rx.recv().await {
                 drop(reply);

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -83,7 +83,11 @@ impl ModbusTcpConnection {
         ModbusTcpSocket::new(host, port, unit_id).connect().await
     }
 
-    /// Returns a new handle that shares the same transport but overrides the default unit id.
+    /// Returns a new handle with a different default unit id.
+    ///
+    /// The returned handle shares the same background actor, TCP session,
+    /// in-flight request window, and retry policy. It does not spawn another
+    /// actor or open another TCP connection.
     #[must_use]
     pub fn with_unit_id(&self, unit_id: u8) -> Self {
         Self {

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -20,14 +20,21 @@ use crate::tcp::socket::ModbusTcpSocket;
 use crate::tcp::timeouts::ModbusTcpTimeouts;
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError};
 
-/// Reusable Modbus TCP client handle.
+/// Live Modbus TCP client handle.
+///
+/// Construct a handle with [`ModbusTcpSocket::connect`] when custom timeouts,
+/// flow control, retry, or an initial transaction-id seed are needed. Use
+/// [`ModbusTcpConnection::connect`] for the default configuration shortcut. Both
+/// paths spawn the background actor and eagerly open the first TCP connection
+/// before returning this live handle.
 ///
 /// Clones are lightweight command senders to a single background actor that owns
 /// the TCP socket, pending response map, and transaction-id counter. The actor
-/// connects lazily on the first warm-up or request, reconnects after transport
-/// teardown, applies bounded in-flight flow control, and uses a bounded request
-/// channel as backpressure. Queue wait is bounded by flow-control settings;
-/// response timeout starts when the actor writes the request on the socket.
+/// reconnects lazily after transport teardown, applies bounded in-flight flow
+/// control, and uses a bounded request channel as backpressure. Queue wait is
+/// bounded by flow-control settings; response timeout starts when the actor
+/// writes the request on the socket. Use [`Self::with_unit_id`] to derive another
+/// live handle that shares the same actor with a different default unit id.
 #[derive(Clone, Debug)]
 pub struct ModbusTcpConnection {
     req_tx: mpsc::Sender<RequestCommand>,

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -31,7 +31,7 @@ use crate::{ModbusRequest, ModbusResponse, error::ModbusError};
 #[derive(Clone, Debug)]
 pub struct ModbusTcpConnection {
     req_tx: mpsc::Sender<RequestCommand>,
-    ctrl_tx: mpsc::Sender<ControlCommand>,
+    pub(crate) ctrl_tx: mpsc::Sender<ControlCommand>,
     unit_id: u8,
     connected: watch::Receiver<bool>,
     queue_timeout: Duration,
@@ -39,6 +39,24 @@ pub struct ModbusTcpConnection {
 }
 
 impl ModbusTcpConnection {
+    pub(crate) fn from_actor_parts(
+        req_tx: mpsc::Sender<RequestCommand>,
+        ctrl_tx: mpsc::Sender<ControlCommand>,
+        unit_id: u8,
+        connected: watch::Receiver<bool>,
+        queue_timeout: Duration,
+        retry: Option<ModbusTcpRetry>,
+    ) -> Self {
+        Self {
+            req_tx,
+            ctrl_tx,
+            unit_id,
+            connected,
+            queue_timeout,
+            retry,
+        }
+    }
+
     /// Creates a connection handle with default connect, write, and read timeouts.
     ///
     /// `host` may be a DNS name or numeric IP address and is resolved whenever
@@ -319,7 +337,7 @@ impl ModbusTcpConnection {
     }
 }
 
-fn actor_terminated_error() -> ModbusError {
+pub(crate) fn actor_terminated_error() -> ModbusError {
     ModbusError::ReadError(Arc::new(io::Error::new(
         io::ErrorKind::ConnectionAborted,
         "reader task terminated",

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -9,14 +9,13 @@ use std::time::Duration;
 
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot, watch};
-use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::debug;
 
-use crate::tcp::actor::{Actor, ControlCommand, RequestCommand, control_channel_capacity};
-use crate::tcp::flow::ModbusTcpFlowControl;
+use crate::tcp::actor::{ControlCommand, RequestCommand};
 use crate::tcp::frame::MBAP_HEADER_LEN;
 use crate::tcp::retry::{ModbusTcpRetry, retry_transient};
+use crate::tcp::socket::ModbusTcpSocket;
 use crate::tcp::timeouts::ModbusTcpTimeouts;
 use crate::{ModbusRequest, ModbusResponse, error::ModbusError};
 
@@ -57,134 +56,23 @@ impl ModbusTcpConnection {
         }
     }
 
-    /// Creates a connection handle with default connect, write, and read timeouts.
+    /// Connects to a Modbus TCP server with default construction settings.
     ///
-    /// `host` may be a DNS name or numeric IP address and is resolved whenever
-    /// the actor opens a TCP connection.
-    #[must_use]
-    pub fn new(host: impl Into<String>, port: u16, unit_id: u8, transaction_id: u16) -> Self {
-        Self::with_timeouts(
-            host,
-            port,
-            unit_id,
-            transaction_id,
-            ModbusTcpTimeouts::default(),
-        )
-    }
-
-    /// Creates a connection handle with explicit timeout settings.
-    ///
-    /// `host` may be a DNS name or numeric IP address and is resolved whenever
-    /// the actor opens a TCP connection.
-    #[must_use]
-    pub fn with_timeouts(
-        host: impl Into<String>,
-        port: u16,
-        unit_id: u8,
-        transaction_id: u16,
-        timeouts: ModbusTcpTimeouts,
-    ) -> Self {
-        Self::spawn_with_config(
-            host.into(),
-            port,
-            unit_id,
-            transaction_id,
-            timeouts,
-            ModbusTcpFlowControl::default(),
-        )
-        .0
-    }
-
-    /// Creates a connection handle with explicit timeout and flow-control settings.
-    ///
-    /// `host` may be a DNS name or numeric IP address and is resolved whenever
-    /// the actor opens a TCP connection.
+    /// `host` may be a DNS name or numeric IP address. `port` is the TCP port,
+    /// and `unit_id` is the default Modbus unit id used by the returned live
+    /// handle. This is a shortcut for configuring a [`ModbusTcpSocket`] with
+    /// defaults and awaiting [`ModbusTcpSocket::connect`].
     ///
     /// # Errors
     ///
-    /// Returns [`ModbusError::ValidationError`] if `flow_control` violates
-    /// [`ModbusTcpFlowControl::validate`]. Flow control is validated
-    /// synchronously because its queue depth is needed before the actor task and
-    /// request channel are spawned; retry policies are validated later when a
-    /// request starts.
-    pub fn with_config(
+    /// Returns validation, connection, timeout, or actor-termination errors from
+    /// [`ModbusTcpSocket::connect`].
+    pub async fn connect(
         host: impl Into<String>,
         port: u16,
         unit_id: u8,
-        transaction_id: u16,
-        timeouts: ModbusTcpTimeouts,
-        flow_control: ModbusTcpFlowControl,
     ) -> Result<Self, ModbusError> {
-        flow_control.validate()?;
-        Ok(Self::spawn_with_config(
-            host.into(),
-            port,
-            unit_id,
-            transaction_id,
-            timeouts,
-            flow_control,
-        )
-        .0)
-    }
-
-    fn spawn_with_config(
-        host: String,
-        port: u16,
-        unit_id: u8,
-        transaction_id: u16,
-        timeouts: ModbusTcpTimeouts,
-        flow_control: ModbusTcpFlowControl,
-    ) -> (Self, JoinHandle<()>) {
-        let (req_tx, req_rx) = mpsc::channel(flow_control.max_queue_depth);
-        let (ctrl_tx, ctrl_rx) = mpsc::channel(control_channel_capacity());
-        let (connected_tx, connected) = watch::channel(false);
-        let actor = Actor::new(
-            host,
-            port,
-            timeouts,
-            flow_control,
-            transaction_id,
-            ctrl_rx,
-            req_rx,
-            connected_tx,
-        );
-        let actor_task = tokio::spawn(actor.run());
-        (
-            Self {
-                req_tx,
-                ctrl_tx,
-                unit_id,
-                connected,
-                queue_timeout: flow_control.queue_timeout,
-                retry: Some(ModbusTcpRetry::default()),
-            },
-            actor_task,
-        )
-    }
-
-    #[cfg(test)]
-    fn spawn_with_timeouts(
-        host: impl Into<String>,
-        port: u16,
-        unit_id: u8,
-        transaction_id: u16,
-        timeouts: ModbusTcpTimeouts,
-    ) -> (Self, JoinHandle<()>) {
-        Self::spawn_with_config(
-            host.into(),
-            port,
-            unit_id,
-            transaction_id,
-            timeouts,
-            ModbusTcpFlowControl::default(),
-        )
-    }
-
-    /// Configures the retry policy used for future send operations on this handle.
-    #[must_use]
-    pub fn with_retry(mut self, retry: Option<ModbusTcpRetry>) -> Self {
-        self.retry = retry;
-        self
+        ModbusTcpSocket::new(host, port, unit_id).connect().await
     }
 
     /// Returns a new handle that shares the same transport but overrides the default unit id.
@@ -211,20 +99,6 @@ impl ModbusTcpConnection {
             .map_err(|error| ModbusError::ConnectError(Arc::new(error)))?;
         debug!(host, port, "connected to Modbus TCP server");
         Ok(stream)
-    }
-
-    /// Opens the TCP connection eagerly.
-    ///
-    /// # Errors
-    ///
-    /// Returns connect or transport errors reported by the actor.
-    pub async fn connect(&self) -> Result<(), ModbusError> {
-        let (ack, reply) = oneshot::channel();
-        self.ctrl_tx
-            .send(ControlCommand::Connect { ack })
-            .await
-            .map_err(|_| actor_terminated_error())?;
-        reply.await.map_err(|_| actor_terminated_error())?
     }
 
     /// Closes the current TCP session if one is open.
@@ -360,20 +234,48 @@ mod tests {
         addr
     }
 
+    fn spawn_actor_with_timeouts(
+        host: impl Into<String>,
+        port: u16,
+        unit_id: u8,
+        transaction_id: u16,
+        timeouts: ModbusTcpTimeouts,
+    ) -> (ModbusTcpConnection, tokio::task::JoinHandle<()>) {
+        ModbusTcpSocket::new(host, port, unit_id)
+            .with_initial_transaction_id(transaction_id)
+            .with_timeouts(timeouts)
+            .spawn_actor()
+    }
+
+    async fn warm_up_actor(connection: &ModbusTcpConnection) -> Result<(), ModbusError> {
+        let (ack, reply) = oneshot::channel();
+        connection
+            .ctrl_tx
+            .send(ControlCommand::Connect { ack })
+            .await
+            .map_err(|_| actor_terminated_error())?;
+        reply.await.map_err(|_| actor_terminated_error())?
+    }
+
     #[tokio::test]
-    async fn connection_starts_disconnected_and_connect_sets_connected() {
+    async fn socket_connect_returns_connected_handle() {
         let addr = accept_and_hold_server().await;
-        let connection = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-        assert!(!connection.is_connected().await);
-        connection.connect().await.unwrap();
+        let connection = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+            .with_initial_transaction_id(0)
+            .connect()
+            .await
+            .unwrap();
         assert!(connection.is_connected().await);
     }
 
     #[tokio::test]
     async fn disconnect_is_idempotent_and_clears_connected() {
         let addr = accept_and_hold_server().await;
-        let connection = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-        connection.connect().await.unwrap();
+        let connection = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+            .with_initial_transaction_id(0)
+            .connect()
+            .await
+            .unwrap();
         connection.disconnect().await;
         connection.disconnect().await;
         assert!(!connection.is_connected().await);
@@ -382,9 +284,11 @@ mod tests {
     #[tokio::test]
     async fn connect_accepts_domain_style_host() {
         let addr = accept_and_hold_server().await;
-        let connection = ModbusTcpConnection::new("localhost", addr.port(), 1, 0);
-
-        connection.connect().await.unwrap();
+        let connection = ModbusTcpSocket::new("localhost", addr.port(), 1)
+            .with_initial_transaction_id(0)
+            .connect()
+            .await
+            .unwrap();
 
         assert!(connection.is_connected().await);
     }
@@ -393,7 +297,7 @@ mod tests {
     async fn actor_exits_after_handles_drop_while_disconnected() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let (connection, actor_task) = ModbusTcpConnection::spawn_with_timeouts(
+        let (connection, actor_task) = spawn_actor_with_timeouts(
             addr.ip().to_string(),
             addr.port(),
             1,
@@ -414,7 +318,7 @@ mod tests {
     #[tokio::test]
     async fn actor_exits_after_handles_drop_while_connected() {
         let addr = accept_and_hold_server().await;
-        let (connection, actor_task) = ModbusTcpConnection::spawn_with_timeouts(
+        let (connection, actor_task) = spawn_actor_with_timeouts(
             addr.ip().to_string(),
             addr.port(),
             1,
@@ -422,7 +326,7 @@ mod tests {
             ModbusTcpTimeouts::default(),
         );
         let clone = connection.clone();
-        connection.connect().await.unwrap();
+        warm_up_actor(&connection).await.unwrap();
         assert!(connection.is_connected().await);
 
         drop(connection);
@@ -436,7 +340,17 @@ mod tests {
 
     #[tokio::test]
     async fn with_unit_id_keeps_retry_policy_and_overrides_unit() {
-        let connection = ModbusTcpConnection::new("127.0.0.1", 502, 1, 0).with_retry(None);
+        let (req_tx, _req_rx) = mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
+        let (_connected_tx, connected) = watch::channel(false);
+        let connection = ModbusTcpConnection::from_actor_parts(
+            req_tx,
+            ctrl_tx,
+            1,
+            connected,
+            Duration::from_millis(50),
+            None,
+        );
         let child = connection.with_unit_id(7);
         assert_eq!(child.retry, None);
         assert_eq!(child.unit_id, 7);
@@ -603,12 +517,30 @@ mod tests {
             write_timeout: Duration::from_millis(50),
             response_timeout: Duration::from_millis(50),
         };
-        let connection =
-            ModbusTcpConnection::with_timeouts(addr.ip().to_string(), addr.port(), 1, 0, timeouts)
-                .with_retry(None);
         assert!(matches!(
-            connection.connect().await,
+            ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+                .with_initial_transaction_id(0)
+                .with_timeouts(timeouts)
+                .connect()
+                .await,
             Err(ModbusError::ConnectError(_) | ModbusError::ConnectTimeout)
         ));
+    }
+
+    #[tokio::test]
+    async fn connect_is_idempotent_while_already_connected() {
+        let addr = accept_and_hold_server().await;
+        let (connection, _actor_task) = spawn_actor_with_timeouts(
+            addr.ip().to_string(),
+            addr.port(),
+            1,
+            0,
+            ModbusTcpTimeouts::default(),
+        );
+
+        warm_up_actor(&connection).await.unwrap();
+        warm_up_actor(&connection).await.unwrap();
+
+        assert!(connection.is_connected().await);
     }
 }

--- a/src/tcp/timeouts.rs
+++ b/src/tcp/timeouts.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_timeouts_match_previous_behavior() {
+    fn default_timeouts_are_five_seconds() {
         let timeouts = ModbusTcpTimeouts::default();
 
         assert_eq!(timeouts.connect_timeout, Duration::from_secs(5));

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -21,7 +21,9 @@ use tokio::sync::Mutex;
 mod support;
 
 use tiny_mb::ModbusError;
-use tiny_mb::tcp::{ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpTimeouts};
+use tiny_mb::tcp::{
+    ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpSocket, ModbusTcpTimeouts,
+};
 use tiny_mb::{ModbusRequest, ModbusResponse};
 
 use support::{
@@ -64,6 +66,16 @@ fn fast_retry(max_elapsed: Duration, max_times: Option<usize>) -> ModbusTcpRetry
     }
 }
 
+async fn wait_until_disconnected(conn: &ModbusTcpConnection) {
+    for _ in 0..10 {
+        if !conn.is_connected().await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(!conn.is_connected().await);
+}
+
 fn make_write_single_register_response(tid: u16, unit_id: u8, address: u16, value: u16) -> Vec<u8> {
     let pdu = vec![
         6u8,
@@ -89,8 +101,9 @@ async fn send_read_coils_success() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -124,8 +137,9 @@ async fn send_write_single_register_success() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::WriteSingleRegister {
         address: 0x0010,
@@ -154,8 +168,11 @@ async fn transaction_id_increments() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 100);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(100)
+        .connect()
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -184,8 +201,9 @@ async fn concurrent_in_flight_requests_are_matched_out_of_order() {
         stream.write_all(&first_response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -259,9 +277,11 @@ async fn server_disconnects_on_write() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
-        .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_retry(Some(fast_retry(Duration::from_millis(500), None)))
+        .connect()
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -322,9 +342,11 @@ async fn server_disconnects_on_header_read() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
-        .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_retry(Some(fast_retry(Duration::from_millis(500), None)))
+        .connect()
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -368,8 +390,9 @@ async fn server_sends_invalid_mbap_length() {
         second_stream.write_all(&response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -398,8 +421,9 @@ async fn send_messages_across_multiple_unit_ids_on_one_connection() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -433,8 +457,9 @@ async fn send_message_returns_exception_response_as_typed_error() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -465,8 +490,9 @@ async fn send_message_returns_protocol_id_mismatch_as_typed_error() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -495,8 +521,9 @@ async fn send_message_returns_unit_id_mismatch_as_typed_error() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
+    let conn = ModbusTcpConnection::connect(addr.ip().to_string(), addr.port(), 1)
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -517,19 +544,17 @@ async fn send_message_returns_unit_id_mismatch_as_typed_error() {
 async fn send_message_returns_read_timeout_from_slow_server() {
     let addr = spawn_slow_server(Duration::from_millis(200)).await.unwrap();
 
-    let conn = ModbusTcpConnection::with_timeouts(
-        addr.ip().to_string(),
-        addr.port(),
-        1,
-        0,
-        ModbusTcpTimeouts {
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_timeouts(ModbusTcpTimeouts {
             connect_timeout: Duration::from_millis(50),
             write_timeout: Duration::from_millis(50),
             response_timeout: Duration::from_millis(25),
-        },
-    )
-    .with_retry(None);
-    conn.connect().await.unwrap();
+        })
+        .with_retry(None)
+        .connect()
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -560,7 +585,11 @@ async fn stray_response_with_unknown_tid_is_ignored() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
         quantity: 2,
@@ -593,17 +622,16 @@ async fn reader_death_drains_pending_and_next_call_reconnects() {
         stream.write_all(&response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::with_timeouts(
-        addr.ip().to_string(),
-        addr.port(),
-        1,
-        0,
-        ModbusTcpTimeouts {
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_timeouts(ModbusTcpTimeouts {
             connect_timeout: Duration::from_millis(100),
             write_timeout: Duration::from_millis(100),
             response_timeout: Duration::from_millis(25),
-        },
-    );
+        })
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
         quantity: 2,
@@ -644,19 +672,17 @@ async fn caller_future_cancellation_does_not_break_following_requests() {
         }
     });
 
-    let conn = ModbusTcpConnection::with_config(
-        addr.ip().to_string(),
-        addr.port(),
-        1,
-        0,
-        ModbusTcpTimeouts {
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_timeouts(ModbusTcpTimeouts {
             connect_timeout: Duration::from_secs(1),
             write_timeout: Duration::from_secs(1),
             response_timeout: Duration::from_secs(1),
-        },
-        ModbusTcpFlowControl::serial_gateway(),
-    )
-    .unwrap();
+        })
+        .with_flow_control(ModbusTcpFlowControl::serial_gateway())
+        .connect()
+        .await
+        .unwrap();
 
     let request = ModbusRequest::ReadCoils {
         starting_address: 0x0000,
@@ -703,19 +729,17 @@ async fn serial_gateway_never_exceeds_one_in_flight_request() {
         stream.write_all(&second_response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::with_config(
-        addr.ip().to_string(),
-        addr.port(),
-        1,
-        0,
-        ModbusTcpTimeouts {
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_timeouts(ModbusTcpTimeouts {
             connect_timeout: Duration::from_secs(1),
             write_timeout: Duration::from_secs(1),
             response_timeout: Duration::from_secs(1),
-        },
-        ModbusTcpFlowControl::serial_gateway(),
-    )
-    .unwrap();
+        })
+        .with_flow_control(ModbusTcpFlowControl::serial_gateway())
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -758,24 +782,22 @@ async fn one_timed_out_tid_is_quarantined_while_sibling_and_socket_survive() {
         stream.write_all(&follow_up_response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::with_config(
-        addr.ip().to_string(),
-        addr.port(),
-        1,
-        0,
-        ModbusTcpTimeouts {
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_timeouts(ModbusTcpTimeouts {
             connect_timeout: Duration::from_secs(1),
             write_timeout: Duration::from_secs(1),
             response_timeout: Duration::from_millis(30),
-        },
-        ModbusTcpFlowControl {
+        })
+        .with_flow_control(ModbusTcpFlowControl {
             max_in_flight: 2,
             quarantine_ttl: Duration::from_secs(1),
             ..ModbusTcpFlowControl::default()
-        },
-    )
-    .unwrap()
-    .with_retry(None);
+        })
+        .with_retry(None)
+        .connect()
+        .await
+        .unwrap();
     let slow_request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -828,8 +850,12 @@ async fn gateway_busy_exception_retries_when_enabled() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
-        .with_retry(Some(fast_retry(Duration::from_millis(500), None)));
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(Some(fast_retry(Duration::from_millis(500), None)))
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -859,12 +885,15 @@ async fn gateway_busy_exception_does_not_retry_when_disabled() {
     })
     .await;
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0).with_retry(Some(
-        ModbusTcpRetry {
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(Some(ModbusTcpRetry {
             retry_gateway_busy: false,
             ..fast_retry(Duration::from_millis(500), None)
-        },
-    ));
+        }))
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -888,13 +917,21 @@ async fn send_message_with_disabled_retry_does_not_retry() {
     tokio::spawn({
         let accepts = Arc::clone(&accepts);
         async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            accepts.fetch_add(1, Ordering::SeqCst);
-            drop(stream);
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                accepts.fetch_add(1, Ordering::SeqCst);
+                drop(stream);
+            }
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0).with_retry(None);
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(None)
+        .connect()
+        .await
+        .unwrap();
+    wait_until_disconnected(&conn).await;
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -903,7 +940,8 @@ async fn send_message_with_disabled_retry_does_not_retry() {
     let error = conn.send_message(&request).await.unwrap_err();
 
     assert!(error.is_transient());
-    assert_eq!(accepts.load(Ordering::SeqCst), 1);
+    // One accept warms up the socket; the second is the no-retry send attempt.
+    assert_eq!(accepts.load(Ordering::SeqCst), 2);
 }
 
 #[tokio::test]
@@ -915,13 +953,22 @@ async fn disabled_retry_still_reconnects_on_next_call() {
         let (stream, _) = listener.accept().await.unwrap();
         drop(stream);
 
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(stream);
+
         let (mut stream, _) = listener.accept().await.unwrap();
         let request = read_request_frame(&mut stream).await.unwrap();
         let response = make_read_coils_response(request.transaction_id, request.unit_id, &[true]);
         stream.write_all(&response).await.unwrap();
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0).with_retry(None);
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(None)
+        .connect()
+        .await
+        .unwrap();
+    wait_until_disconnected(&conn).await;
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -952,8 +999,12 @@ async fn send_message_with_custom_retry_honors_max_elapsed() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
-        .with_retry(Some(fast_retry(Duration::from_millis(100), None)));
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(Some(fast_retry(Duration::from_millis(100), None)))
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -985,8 +1036,13 @@ async fn send_message_with_max_times_caps_attempts() {
         }
     });
 
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0)
-        .with_retry(Some(fast_retry(Duration::from_secs(5), Some(2))));
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(Some(fast_retry(Duration::from_secs(5), Some(2))))
+        .connect()
+        .await
+        .unwrap();
+    wait_until_disconnected(&conn).await;
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -996,16 +1052,26 @@ async fn send_message_with_max_times_caps_attempts() {
     let error = conn.send_message(&request).await.unwrap_err();
 
     assert!(error.is_transient());
-    assert_eq!(accepts.load(Ordering::SeqCst), 3);
+    // One accept warms up the socket, followed by the initial send and two retries.
+    assert_eq!(accepts.load(Ordering::SeqCst), 4);
     assert!(started.elapsed() < Duration::from_millis(250));
 }
 
 #[tokio::test]
 async fn invalid_retry_policy_surfaces_as_validation_error() {
-    let conn = ModbusTcpConnection::new("127.0.0.1", 502, 1, 0).with_retry(Some(ModbusTcpRetry {
-        initial_delay: Duration::ZERO,
-        ..ModbusTcpRetry::default()
-    }));
+    let addr = spawn_mock_server(|mut stream| async move {
+        let _ = read_request_frame(&mut stream).await;
+    })
+    .await;
+    let conn = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_retry(Some(ModbusTcpRetry {
+            initial_delay: Duration::ZERO,
+            ..ModbusTcpRetry::default()
+        }))
+        .connect()
+        .await
+        .unwrap();
     let request = ModbusRequest::ReadCoils {
         starting_address: 0,
         quantity: 1,
@@ -1022,9 +1088,9 @@ async fn invalid_retry_policy_surfaces_as_validation_error() {
 }
 
 #[tokio::test]
-async fn first_request_lazily_connects_and_reports_connect_failure() {
-    // Bind then drop the listener so the port is closed: the actor dials lazily on
-    // the first request and must surface the connect error to the caller.
+async fn socket_connect_reports_connect_failure() {
+    // Bind then drop the listener so the port is closed: socket construction
+    // eagerly opens the first connection and must surface the connect error.
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -1034,36 +1100,17 @@ async fn first_request_lazily_connects_and_reports_connect_failure() {
         write_timeout: Duration::from_millis(50),
         response_timeout: Duration::from_millis(200),
     };
-    let conn =
-        ModbusTcpConnection::with_timeouts(addr.ip().to_string(), addr.port(), 1, 0, timeouts)
-            .with_retry(None);
 
-    let request = ModbusRequest::ReadHoldingRegisters {
-        starting_address: 0,
-        quantity: 1,
-    };
-    let error = conn.send_message(&request).await.unwrap_err();
+    let error = ModbusTcpSocket::new(addr.ip().to_string(), addr.port(), 1)
+        .with_initial_transaction_id(0)
+        .with_timeouts(timeouts)
+        .with_retry(None)
+        .connect()
+        .await
+        .unwrap_err();
 
     assert!(matches!(
         error,
         ModbusError::ConnectError(_) | ModbusError::ConnectTimeout
     ));
-    assert!(!conn.is_connected().await);
-}
-
-#[tokio::test]
-async fn connect_is_idempotent_while_already_connected() {
-    let addr = spawn_mock_server(|mut stream| async move {
-        // Keep the connection open so the second connect observes the live socket.
-        let mut buf = [0u8; 16];
-        let _ = stream.read(&mut buf).await;
-    })
-    .await;
-
-    let conn = ModbusTcpConnection::new(addr.ip().to_string(), addr.port(), 1, 0);
-    conn.connect().await.unwrap();
-    // The second connect must take the already-connected fast path and stay open.
-    conn.connect().await.unwrap();
-
-    assert!(conn.is_connected().await);
 }


### PR DESCRIPTION
## Summary
- introduce `ModbusTcpSocket` as the configurable pre-connect construction phase
- keep `ModbusTcpConnection` as the live actor-backed handle returned by `connect()`
- move timeout, retry, flow-control, and initial transaction-id configuration to `ModbusTcpSocket`
- document the new two-phase API in README and TCP module docs
- update examples and integration tests to use the new construction flow

## Why
Separating configuration from the live connection makes the API clearer:
configuration no longer implies an already-running actor or open socket, while
`ModbusTcpConnection` now consistently represents an active, actor-backed client
handle. This also makes eager first-connect behavior and shared-handle semantics
easier to explain and use correctly.

## Breaking changes
- construction modifiers were removed from `ModbusTcpConnection`
- use `ModbusTcpSocket::new(...).with_...().connect().await` for custom TCP configuration
- `ModbusTcpConnection::connect(...)` remains as the default-configuration shortcut

## Example migration
```rust
let connection = ModbusTcpSocket::new("localhost", 502, 1)
    .with_timeouts(timeouts)
    .with_flow_control(flow_control)
    .with_retry(Some(retry))
    .connect()
    .await?;
```