### PR TITLE
chore(rename): rename tiny-mb to ferrobus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ferrobus"
+version = "0.1.0"
+dependencies = [
+ "backon",
+ "bytes",
+ "clap",
+ "futures-util",
+ "socket2 0.5.10",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,22 +397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiny-mb"
-version = "0.1.0"
-dependencies = [
- "backon",
- "bytes",
- "clap",
- "futures-util",
- "socket2 0.5.10",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tiny-mb"
+name = "ferrobus"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tinymb contributors
+Copyright (c) 2025 ferrobus contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# tiny-mb
+# ferrobus
 
-[![CI](https://github.com/mattwend/tiny-mb/actions/workflows/ci.yml/badge.svg)](https://github.com/mattwend/tiny-mb/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/mattwend/tiny-mb/branch/v0.x.x/graph/badge.svg)](https://codecov.io/gh/mattwend/tiny-mb)
+[![CI](https://github.com/mattwend/ferrobus/actions/workflows/ci.yml/badge.svg)](https://github.com/mattwend/ferrobus/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/mattwend/ferrobus/branch/v0.x.x/graph/badge.svg)](https://codecov.io/gh/mattwend/ferrobus)
 
 Small Rust Modbus library with typed request/response PDUs and a reusable Modbus TCP transport.
 
@@ -38,7 +38,7 @@ Add the crate to your project:
 
 ```toml
 [dependencies]
-tiny-mb = "0.1.0"
+ferrobus = "0.1.0"
 ```
 
 ## Library usage
@@ -46,11 +46,11 @@ tiny-mb = "0.1.0"
 Create a typed request and send it over Modbus TCP:
 
 ```rust
-use tiny_mb::tcp::ModbusTcpConnection;
-use tiny_mb::{ModbusRequest, ModbusResponse};
+use ferrobus::tcp::ModbusTcpConnection;
+use ferrobus::{ModbusRequest, ModbusResponse};
 
 #[tokio::main]
-async fn main() -> Result<(), tiny_mb::ModbusError> {
+async fn main() -> Result<(), ferrobus::ModbusError> {
     let connection = ModbusTcpConnection::connect("127.0.0.1", 502, 1).await?;
 
     let response = connection
@@ -94,7 +94,7 @@ configure a `ModbusTcpSocket` before calling `connect().await`.
 ```rust
 use std::time::Duration;
 
-use tiny_mb::tcp::{ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpSocket, ModbusTcpTimeouts};
+use ferrobus::tcp::{ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpSocket, ModbusTcpTimeouts};
 
 let connection = ModbusTcpSocket::new("localhost", 502, 1)
     .with_timeouts(ModbusTcpTimeouts {

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# cargo-deny configuration for tiny-mb.
+# cargo-deny configuration for ferrobus.
 #
 # Run `cargo deny check` to validate the dependency graph against the
 # policies below. The config uses the v2 schema; see

--- a/examples/concurrent_clients.rs
+++ b/examples/concurrent_clients.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tiny-mb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Issues concurrent Modbus TCP requests over one shared connection.
 //!
@@ -8,8 +8,8 @@
 
 use std::error::Error;
 
-use tiny_mb::ModbusRequest;
-use tiny_mb::tcp::ModbusTcpConnection;
+use ferrobus::ModbusRequest;
+use ferrobus::tcp::ModbusTcpConnection;
 use tracing::info;
 
 #[tokio::main]
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             let response = client.send_message(&request).await?;
             info!(offset, ?response, "received concurrent Modbus response");
-            Ok::<_, tiny_mb::ModbusError>(())
+            Ok::<_, ferrobus::ModbusError>(())
         }));
     }
 

--- a/examples/modbus_cli.rs
+++ b/examples/modbus_cli.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tiny-mb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 #![allow(missing_docs, clippy::match_same_arms, clippy::uninlined_format_args)]
 
@@ -9,10 +9,10 @@ use std::process;
 use tracing::info;
 use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
-use tiny_mb::ModbusError;
-use tiny_mb::ModbusRequest;
-use tiny_mb::ModbusResponse;
-use tiny_mb::tcp::ModbusTcpSocket;
+use ferrobus::ModbusError;
+use ferrobus::ModbusRequest;
+use ferrobus::ModbusResponse;
+use ferrobus::tcp::ModbusTcpSocket;
 
 // ---------------------------------------------------------------------------
 // CLI definition
@@ -20,7 +20,7 @@ use tiny_mb::tcp::ModbusTcpSocket;
 
 #[derive(Parser, Debug)]
 #[command(name = "modbus_cli")]
-#[command(about = "Modbus TCP client for the tiny-mb library")]
+#[command(about = "Modbus TCP client for the ferrobus library")]
 #[command(long_about = "\
 Connects to a Modbus TCP device and issues one request at a time.\n\
 \n\

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 #![deny(missing_docs)]
 
-//! `tiny-mb` provides small, explicit Modbus request/response types plus a
+//! `ferrobus` provides small, explicit Modbus request/response types plus a
 //! Modbus TCP transport.
 //!
 //! The crate is organized around typed PDUs:

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 use crate::error::ModbusError;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 use std::convert::TryFrom;
 

--- a/src/tcp/actor.rs
+++ b/src/tcp/actor.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Single-owner Modbus TCP connection actor.
 

--- a/src/tcp/adu.rs
+++ b/src/tcp/adu.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 use crate::error::ModbusError;
 use crate::request::ModbusRequest;

--- a/src/tcp/codec.rs
+++ b/src/tcp/codec.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Modbus TCP MBAP codec used by the connection actor.
 

--- a/src/tcp/flow.rs
+++ b/src/tcp/flow.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Application-layer flow control for Modbus TCP actors.
 

--- a/src/tcp/frame.rs
+++ b/src/tcp/frame.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! MBAP header constants and response frame length validation.
 

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Modbus TCP framing and transport helpers.
 //!

--- a/src/tcp/retry.rs
+++ b/src/tcp/retry.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Retry configuration for Modbus TCP send operations.
 

--- a/src/tcp/socket.rs
+++ b/src/tcp/socket.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Configurable Modbus TCP socket phase.
 

--- a/src/tcp/tcp_connection.rs
+++ b/src/tcp/tcp_connection.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Public Modbus TCP connection handle and request orchestration.
 

--- a/src/tcp/timeouts.rs
+++ b/src/tcp/timeouts.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 //! Timeout configuration for Modbus TCP operations.
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 #![allow(
     missing_docs,

--- a/tests/tcp_integration.rs
+++ b/tests/tcp_integration.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 tinymb contributors
+// Copyright (c) 2025 ferrobus contributors
 
 #![allow(
     missing_docs,
@@ -20,11 +20,11 @@ use tokio::sync::Mutex;
 
 mod support;
 
-use tiny_mb::ModbusError;
-use tiny_mb::tcp::{
+use ferrobus::ModbusError;
+use ferrobus::tcp::{
     ModbusTcpConnection, ModbusTcpFlowControl, ModbusTcpRetry, ModbusTcpSocket, ModbusTcpTimeouts,
 };
-use tiny_mb::{ModbusRequest, ModbusResponse};
+use ferrobus::{ModbusRequest, ModbusResponse};
 
 use support::{
     build_exception_response_frame, build_protocol_mismatch_frame, build_tcp_response_frame,


### PR DESCRIPTION
Rename the crate and all user-facing references to ferrobus so the package name, docs, examples, and tests consistently use the new project identity.